### PR TITLE
docs: CHANGELOGスナップショットの著作権表示を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ gh workflow run changelog-monitor.yml
 
 MIT License
 
+### サードパーティコンテンツ
+
+`.changelog-snapshot.md` はClaude Code公式リポジトリのCHANGELOGのスナップショットであり、Anthropic, PBC の著作物です。このファイルはCHANGELOG監視機能の差分検出のために使用されており、元のライセンスはAnthropicに帰属します。
+
+- 元ファイル: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- 著作権: © Anthropic, PBC
+
 ---
 
 **注意**: このリポジトリはコミュニティ主導のプロジェクトであり、Anthropic社の公式プロジェクトではありません。


### PR DESCRIPTION
## Summary

- `.changelog-snapshot.md`がAnthropic, PBCの著作物であることをREADMEに明記
- 元ファイルのURLと著作権表示を追加

## 背景

`.changelog-snapshot.md`はClaude Code公式リポジトリのCHANGELOGをそのままコピーしたスナップショットファイルであり、Anthropicに著作権があるため、ライセンス上の注釈が必要でした。

## Test plan

- [ ] READMEの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)