### PR TITLE
feat(ci): Dependabotによる依存関係自動更新を設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # GitHub Actionsのバージョン自動更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci/cd"

--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Claude Codeをインストール
         if: (steps.check-diff.outputs.changed == 'true' && steps.check-diff.outputs.is_first_run == 'false') || inputs.force_check
-        run: npm install -g @anthropic-ai/claude-code@2.0.76
+        run: npm install -g @anthropic-ai/claude-code
 
       - name: Claudeで変更を解析しIssue/PRを作成
         id: claude-analysis


### PR DESCRIPTION
## Summary

- GitHub Actionsの依存関係を週次で自動更新するDependabotを設定
- `changelog-monitor.yml`のClaude Codeバージョン固定（`@2.0.76`）を解除し、常に最新版を使用

## 変更内容

| ファイル | 変更 |
|----------|------|
| `.github/dependabot.yml` | 新規作成 |
| `.github/workflows/changelog-monitor.yml` | バージョン指定を削除 |

## 補足

issueで提案されたRenovateではなく、よりシンプルなDependabotを採用しました。

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)