### PR TITLE
docs(rules): README.md（索引・用語集）を作成

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,39 @@
+# ルールドキュメント索引
+
+このディレクトリにはClaude Codeプラグイン開発のためのルールドキュメントが含まれています。
+
+## ファイル一覧
+
+| ファイル | 概要 |
+|---------|------|
+| [plugin-manifest.md](plugin-manifest.md) | プラグインの定義ファイル（`plugin.json`）の仕様 |
+| [marketplace.md](marketplace.md) | マーケットプレイス設定（`marketplace.json`）の仕様 |
+| [agents.md](agents.md) | サブエージェントの定義方法 |
+| [hooks.md](hooks.md) | フック（イベントハンドラ）の定義方法 |
+| [mcp-servers.md](mcp-servers.md) | MCPサーバーの設定方法 |
+| [lsp-servers.md](lsp-servers.md) | LSPサーバーの設定方法 |
+| [skill-authoring.md](skill-authoring.md) | スキル作成のベストプラクティス |
+| [slash-commands.md](slash-commands.md) | スラッシュコマンドの定義方法 |
+
+## 用語集
+
+| 用語 | 説明 |
+|------|------|
+| kebab-case | 単語をハイフンで繋ぐ命名規則。例: `my-plugin-name` |
+| フロントマター | Markdownファイル冒頭の`---`で囲まれたYAMLメタデータ領域 |
+| MCP | Model Context Protocol。Claude Codeが外部サービスと通信するためのプロトコル |
+| SSE | Server-Sent Events。サーバーからクライアントへの一方向ストリーミング通信 |
+| LSP | Language Server Protocol。エディタと言語サーバー間の標準プロトコル |
+
+## 環境変数リファレンス
+
+プラグイン内で使用可能な環境変数:
+
+| 変数 | 説明 | 使用箇所 |
+|------|------|----------|
+| `${CLAUDE_PLUGIN_ROOT}` | プラグインルートへの絶対パス | hooks, mcp-servers, lsp-servers |
+| `${CLAUDE_PROJECT_DIR}` | プロジェクトルートへの絶対パス | hooks |
+| `$ARGUMENTS` | フック入力JSON / コマンド引数 | hooks, slash-commands |
+| `$1`, `$2`, `$3`... | 位置指定引数 | slash-commands |
+| `${VAR}` | 任意の環境変数を展開 | mcp-servers, lsp-servers |
+| `${VAR:-default}` | デフォルト値付き環境変数 | mcp-servers, lsp-servers |


### PR DESCRIPTION
## Summary

- `.claude/rules/README.md` を新規作成
- 全8ルールファイルへのリンクと概要を含む索引セクション
- 用語集（kebab-case、フロントマター、MCP、SSE、LSP）
- 分散していた環境変数リファレンスの一元化

## 対応方針

Issue #18 の要件を検討した結果、以下の方針で実装しました：

**採用した項目：**
- 索引セクション（シンプルな一覧形式）
- 用語集セクション
- 環境変数リファレンス

**見送った項目：**
- 各ルールファイルへの「関連項目」セクション追加
  - 理由：既存ファイルへの変更は保守コストを増やすため、READMEからのリンクで代替

## Test plan

- [ ] `.claude/rules/README.md` が正しく作成されている
- [ ] 全ルールファイルへのリンクが有効
- [ ] 用語集の説明が適切
- [ ] 環境変数リファレンスが各ファイルの内容と整合

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)