### PR TITLE
refactor(validators): シークレットパターン検証とkebab-case検証を共通化

### DIFF
--- a/scripts/validators/agent.py
+++ b/scripts/validators/agent.py
@@ -2,10 +2,9 @@
 サブエージェントのバリデーター
 """
 
-import re
 from pathlib import Path
 
-from .base import ValidationResult, parse_frontmatter
+from .base import ValidationResult, parse_frontmatter, validate_kebab_case
 
 
 def validate_agent(file_path: Path, content: str) -> ValidationResult:
@@ -24,10 +23,9 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
         result.add_error(f"{file_path.name}: nameが必須です")
     else:
         # kebab-case（小文字とハイフンのみ）チェック
-        if not re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name_str):
-            result.add_error(
-                f"{file_path.name}: nameはkebab-case（小文字とハイフン）のみ: {name_str}"
-            )
+        kebab_error = validate_kebab_case(name_str)
+        if kebab_error:
+            result.add_error(f"{file_path.name}: {kebab_error}")
 
     # descriptionの確認
     description = frontmatter.get("description", "")

--- a/scripts/validators/base.py
+++ b/scripts/validators/base.py
@@ -2,7 +2,30 @@
 共通ユーティリティ: ValidationResult と parse_frontmatter
 """
 
+import re
+from pathlib import Path
 from typing import Any
+
+# kebab-case検証用の正規表現（プリコンパイル）
+KEBAB_CASE_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# シークレット検出用パターン（プリコンパイル）
+SECRET_PATTERNS = [
+    (re.compile(r"sk-[a-zA-Z0-9]{32,}"), "OpenAI APIキー"),
+    (re.compile(r"sk-proj-[a-zA-Z0-9]{32,}"), "OpenAI Project APIキー"),
+    (re.compile(r"ghp_[a-zA-Z0-9]{36}"), "GitHub Personal Access Token"),
+    (re.compile(r"gho_[a-zA-Z0-9]{36}"), "GitHub OAuth Token"),
+    (re.compile(r"ghu_[a-zA-Z0-9]{36}"), "GitHub User Token"),
+    (re.compile(r"ghs_[a-zA-Z0-9]{36}"), "GitHub Server Token"),
+    (re.compile(r"xoxb-[a-zA-Z0-9-]+"), "Slack Bot Token"),
+    (re.compile(r"xoxa-[a-zA-Z0-9-]+"), "Slack App Token"),
+    (re.compile(r"xoxp-[a-zA-Z0-9-]+"), "Slack User Token"),
+    (re.compile(r"AKIA[A-Z0-9]{16}"), "AWS Access Key ID"),
+    (re.compile(r"AIza[a-zA-Z0-9_-]{35}"), "Google API Key"),
+]
+
+# 汎用的な機密情報パターン（長い英数字文字列）
+GENERIC_SECRET_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class ValidationResult:
@@ -105,3 +128,54 @@ def parse_frontmatter(content: str) -> tuple[dict[str, Any], str, list[str]]:
                 frontmatter[key] = value
 
     return frontmatter, body, warnings
+
+
+def validate_kebab_case(name: str) -> str | None:
+    """
+    kebab-case形式（小文字とハイフン）を検証する
+
+    Args:
+        name: 検証する文字列
+
+    Returns:
+        エラーメッセージ。問題なければNone
+    """
+    if not KEBAB_CASE_PATTERN.match(name):
+        return f"nameはkebab-case（小文字とハイフン）のみ: {name}"
+    return None
+
+
+def check_env_secrets(
+    result: ValidationResult,
+    file_path: Path,
+    context_name: str,
+    env: dict,
+) -> None:
+    """
+    環境変数に機密情報が直接記述されていないかチェック
+
+    Args:
+        result: 検証結果オブジェクト
+        file_path: 検証対象ファイルのパス
+        context_name: エラーメッセージに含めるコンテキスト名（サーバー名など）
+        env: 環境変数の辞書
+    """
+    for key, value in env.items():
+        if not isinstance(value, str) or value.startswith("${"):
+            continue
+
+        # 既知の機密情報パターンをチェック
+        for pattern, description in SECRET_PATTERNS:
+            if pattern.search(value):
+                result.add_error(
+                    f"{file_path.name}: {context_name}: "
+                    f"envの{key}に{description}が直接記述。${{{{VAR}}}}形式を使用"
+                )
+                break
+        else:
+            # 既知パターンに一致しない場合、汎用チェック（警告）
+            if len(value) > 20 and GENERIC_SECRET_PATTERN.match(value):
+                result.add_warning(
+                    f"{file_path.name}: {context_name}: "
+                    f"envの{key}に機密情報の可能性。${{{{VAR}}}}形式を使用"
+                )

--- a/scripts/validators/mcp_json.py
+++ b/scripts/validators/mcp_json.py
@@ -3,10 +3,9 @@
 """
 
 import json
-import re
 from pathlib import Path
 
-from .base import ValidationResult
+from .base import ValidationResult, check_env_secrets
 
 
 def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
@@ -44,36 +43,6 @@ def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
 
         # 環境変数の直接記述をチェック
         env = config.get("env", {})
-        for key, value in env.items():
-            if isinstance(value, str) and not value.startswith("${"):
-                # 既知の機密情報パターン（検出時はエラー）
-                secret_patterns = [
-                    (r"sk-[a-zA-Z0-9]{32,}", "OpenAI APIキー"),
-                    (r"sk-proj-[a-zA-Z0-9]{32,}", "OpenAI Project APIキー"),
-                    (r"ghp_[a-zA-Z0-9]{36}", "GitHub Personal Access Token"),
-                    (r"gho_[a-zA-Z0-9]{36}", "GitHub OAuth Token"),
-                    (r"ghu_[a-zA-Z0-9]{36}", "GitHub User Token"),
-                    (r"ghs_[a-zA-Z0-9]{36}", "GitHub Server Token"),
-                    (r"xoxb-[a-zA-Z0-9-]+", "Slack Bot Token"),
-                    (r"xoxa-[a-zA-Z0-9-]+", "Slack App Token"),
-                    (r"xoxp-[a-zA-Z0-9-]+", "Slack User Token"),
-                    (r"AKIA[A-Z0-9]{16}", "AWS Access Key ID"),
-                    (r"AIza[a-zA-Z0-9_-]{35}", "Google API Key"),
-                ]
-
-                for pattern, description in secret_patterns:
-                    if re.search(pattern, value):
-                        result.add_error(
-                            f"{file_path.name}: {server_name}: "
-                            f"envの{key}に{description}が直接記述。${{{{VAR}}}}形式を使用"
-                        )
-                        break
-                else:
-                    # 既知パターンに一致しない場合、汎用チェック（警告）
-                    if len(value) > 20 and re.match(r"^[a-zA-Z0-9_-]+$", value):
-                        result.add_warning(
-                            f"{file_path.name}: {server_name}: "
-                            f"envの{key}に機密情報の可能性。${{{{VAR}}}}形式を使用"
-                        )
+        check_env_secrets(result, file_path, server_name, env)
 
     return result

--- a/scripts/validators/plugin_json.py
+++ b/scripts/validators/plugin_json.py
@@ -6,7 +6,7 @@ import json
 import re
 from pathlib import Path
 
-from .base import ValidationResult
+from .base import ValidationResult, validate_kebab_case
 
 
 def validate_plugin_json(file_path: Path, content: str) -> ValidationResult:
@@ -25,10 +25,9 @@ def validate_plugin_json(file_path: Path, content: str) -> ValidationResult:
     else:
         name = data["name"]
         # kebab-caseチェック
-        if not re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name):
-            result.add_error(
-                f"{file_path.name}: nameはkebab-case（小文字とハイフン）で記述してください: {name}"
-            )
+        kebab_error = validate_kebab_case(name)
+        if kebab_error:
+            result.add_error(f"{file_path.name}: {kebab_error}")
         if " " in name:
             result.add_error(f"{file_path.name}: nameにスペースは使用できません")
 


### PR DESCRIPTION
## Summary

- `check_env_secrets()`: `mcp_json.py` と `lsp_json.py` で重複していたシークレットパターン検証ロジック（約25行×2）を `base.py` に集約
- `validate_kebab_case()`: `agent.py` と `plugin_json.py` で重複していたkebab-case検証を `base.py` に集約
- 正規表現をモジュールレベルでプリコンパイル

## Test plan

- [x] 全110件のテストがパス
- [x] コード行数: +87行 / -85行（実質的に同等だが重複コード削減）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)