### PR TITLE
docs(rules): modelフィールドを短縮形に統一

### DIFF
--- a/.claude/rules/slash-commands.md
+++ b/.claude/rules/slash-commands.md
@@ -12,7 +12,7 @@ Markdown + YAML Frontmatter形式で記述します。
 ---
 description: コマンドの説明
 allowed-tools: Bash(git add:*), Bash(git commit:*)
-model: claude-3-5-haiku-20241022
+model: haiku
 argument-hint: [message]
 disable-model-invocation: false
 ---
@@ -28,7 +28,7 @@ $ARGUMENTS で引数を受け取れます
 |-----------|------|------|-----------|
 | `description` | No | コマンドの説明（`/help`で表示） | プロンプトの最初の行 |
 | `allowed-tools` | No | 使用可能なツール（カンマ区切り） | 会話から継承 |
-| `model` | No | 使用するモデル | 会話から継承 |
+| `model` | No | 使用するモデル（`sonnet`, `opus`, `haiku`）| 未指定時は会話のモデルを使用 |
 | `argument-hint` | No | 引数のヒント（オートコンプリート表示） | なし |
 | `disable-model-invocation` | No | SlashCommandツール経由の実行を防止 | `false` |
 
@@ -63,3 +63,11 @@ allowed-tools: Bash(deploy:*)
 
 - `true`: Claudeの自動実行を禁止（ユーザーの手動実行のみ可能）
 - `false`: Claudeが会話中に自動実行可能
+
+## フィールド命名規則について
+
+フロントマターのフィールド名は**Claude Code本体の仕様**に従っています。
+
+- `allowed-tools`, `argument-hint`, `disable-model-invocation`: kebab-case（Claude Code公式仕様）
+
+この命名規則は当プロジェクト独自のものではなく、Claude Codeでそのまま使用できる形式です。`agents.md`の`permissionMode`（camelCase）も同様にClaude Code本体の仕様に従っています。

--- a/scripts/tests/test_slash_command.py
+++ b/scripts/tests/test_slash_command.py
@@ -91,3 +91,41 @@ class TestValidateSlashCommand:
         """).strip()
         result = validate_slash_command(Path("test.md"), content)
         assert any("model" in w for w in result.warnings)
+
+    def test_valid_short_models(self):
+        """短縮形のmodelが受け入れられることを確認"""
+        for model in ["sonnet", "opus", "haiku"]:
+            content = dedent(f"""
+                ---
+                description: テスト
+                model: {model}
+                ---
+                本文
+            """).strip()
+            result = validate_slash_command(Path("test.md"), content)
+            assert not result.has_errors(), f"model={model} でエラーが発生"
+            assert not any("model" in w for w in result.warnings), f"model={model} で警告が発生"
+
+    def test_inherit_not_allowed(self):
+        """スラッシュコマンドではinheritは使用不可"""
+        content = dedent("""
+            ---
+            description: テスト
+            model: inherit
+            ---
+            本文
+        """).strip()
+        result = validate_slash_command(Path("test.md"), content)
+        assert any("model" in w for w in result.warnings)
+
+    def test_full_model_id_not_allowed(self):
+        """完全なモデルIDは警告される"""
+        content = dedent("""
+            ---
+            description: テスト
+            model: claude-3-5-haiku-20241022
+            ---
+            本文
+        """).strip()
+        result = validate_slash_command(Path("test.md"), content)
+        assert any("model" in w for w in result.warnings)

--- a/scripts/validators/slash_command.py
+++ b/scripts/validators/slash_command.py
@@ -47,9 +47,11 @@ def validate_slash_command(file_path: Path, content: str) -> ValidationResult:
                 f"{file_path.name}: 危険な操作の可能性。disable-model-invocation: trueを検討"
             )
 
-    # modelの値チェック
-    model = frontmatter.get("model", "")
-    if model and not any(m in str(model) for m in ["haiku", "sonnet", "opus"]):
-        result.add_warning(f"{file_path.name}: modelの値が不明です: {model}")
+    # modelの値チェック（短縮形のみ許可、inheritは不可）
+    model = frontmatter.get("model")
+    model_str = str(model).strip() if model is not None else ""
+    valid_models = {"sonnet", "opus", "haiku"}
+    if model_str and model_str not in valid_models:
+        result.add_warning(f"{file_path.name}: modelが不正: {model_str}（sonnet/opus/haiku）")
 
     return result


### PR DESCRIPTION
## Summary

- `slash-commands.md` の model フィールド例を `claude-3-5-haiku-20241022` → `haiku` に修正
- バリデータを短縮形（`sonnet`, `opus`, `haiku`）のみ許可するよう更新
- フィールド命名規則についての説明セクションを追加

## 対応方針

Issue #17 の指摘のうち、**modelフィールドの統一のみ対応**しました。

### 対応しなかった項目: フィールド命名規則の統一

フィールド名（`permissionMode`, `allowed-tools` 等）は **Claude Code本体の仕様** に従っています。無理に統一すると、ユーザーが実際にClaude Codeで使用する際に認識されなくなるリスクがあるため、変更しませんでした。代わりに、ドキュメントに説明セクションを追加しました。

## Test plan

- [ ] バリデータが短縮形以外のmodelで警告を出すことを確認
- [ ] CIが通ることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)