### PR TITLE
refactor(ci): curlにリトライオプションを追加

### DIFF
--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 最新のCHANGELOGを取得
         id: fetch
         run: |
-          if curl -fsSL https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md -o current-changelog.md; then
+          if curl --retry 3 --retry-delay 5 -fsSL https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md -o current-changelog.md; then
             echo "success=true" >> $GITHUB_OUTPUT
             echo "取得完了: $(wc -l < current-changelog.md) 行"
           else


### PR DESCRIPTION
## Summary

- changelog-monitor.ymlのCHANGELOG取得curlコマンドに`--retry 3 --retry-delay 5`オプションを追加
- 一時的なネットワーク障害でワークフローが失敗するリスクを軽減

## 背景

Issue #24で指摘された問題のうち、実際に価値のある改善のみを実施。

**実施した内容:**
- curlにリトライオプションを追加（外部依存なし、シンプルな解決策）

**実施しなかった内容（理由）:**
- バージョン環境変数化: 現状すでに`latest`でインストールしており問題なし
- URL環境変数化: 変更される可能性が極めて低く、メリットがない
- Composite Action分割: 139行は長くなく、分割は過剰設計

Closes #24

## Test plan

- [ ] workflow_dispatchで手動実行し、CHANGELOG取得が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)