### PR TITLE
feat(scripts): テストカバレッジ計測を導入

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -20,5 +20,40 @@ jobs:
       - name: uvをセットアップ
         uses: astral-sh/setup-uv@v7
 
-      - name: テストを実行
-        run: uvx pytest scripts/tests/ -v
+      - name: テストを実行（カバレッジ計測）
+        working-directory: scripts
+        run: |
+          uvx --with pytest-cov pytest tests/ -v \
+            --cov=validators \
+            --cov-report=term \
+            --cov-report=html:htmlcov \
+            --cov-report=json:coverage.json \
+            --cov-fail-under=80
+
+      - name: カバレッジレポートをアーティファクトとして保存
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: scripts/htmlcov/
+
+      - name: カバレッジ値を抽出
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        working-directory: scripts
+        run: |
+          COVERAGE=$(python3 -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered']))")
+          echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
+      - name: カバレッジバッジを更新
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage.json
+          label: coverage
+          message: ${{ env.COVERAGE }}%
+          valColorRange: ${{ env.COVERAGE }}
+          minColorRange: 50
+          maxColorRange: 90
+          namedLogo: pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ python3 scripts/validate_plugin.py plugins/my-plugin/**/*.md plugins/my-plugin/*
 ```bash
 # テストを実行（uvを使用）
 uvx pytest scripts/tests/ -v
+
+# カバレッジ付きでテストを実行
+uvx --with pytest-cov pytest scripts/tests/ -v --cov=scripts/validators --cov-report=term
 ```
 
 ### Linter/Formatter

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Code Marketplace
 
+[![テスト](https://github.com/rfdnxbro/claude-code-marketplace/actions/workflows/test-scripts.yml/badge.svg)](https://github.com/rfdnxbro/claude-code-marketplace/actions/workflows/test-scripts.yml)
+![カバレッジ](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/rfdnxbro/584b9ff17fd95a2c4aa38dcf30c5a391/raw/coverage.json)
+
 Claude Codeの機能を拡張するプラグイン（スラッシュコマンド、MCPサーバー、フック、サブエージェント）を共有・発見できるマーケットプレイスです。
 
 ## 概要
@@ -115,7 +118,7 @@ claude --plugin-dir ./plugins/my-plugin
 
 ```bash
 # Pythonスクリプトで検証
-python3 scripts/validate_plugin.py ./plugins/my-plugin
+python3 scripts/validate_plugin.py plugins/my-plugin/**/*.md plugins/my-plugin/**/*.json
 
 # テストを実行
 uvx pytest scripts/tests/ -v
@@ -136,10 +139,20 @@ uvx pytest scripts/tests/ -v
 - `hooks.json` - フック設定
 - `.mcp.json` - MCPサーバー設定
 - `.lsp.json` - LSPサーバー設定
+- `README.md` - プラグインREADME
+- `output-styles/*.md` - 出力スタイル
 
 ### スクリプトテスト
 
 `scripts/`配下のファイルが変更されると、自動的にpytestが実行されます。
+
+#### カバレッジバッジのセットアップ
+
+カバレッジバッジを有効にするには以下の設定が必要です：
+
+1. [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens)で`gist`スコープのトークンを生成
+2. リポジトリのSecrets（`GIST_SECRET`）にトークンを設定
+3. リポジトリのVariables（`COVERAGE_GIST_ID`）に`584b9ff17fd95a2c4aa38dcf30c5a391`を設定
 
 ### CHANGELOG監視
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,6 +73,9 @@ python3 scripts/validate_plugin.py plugins/my-plugin/**/*.md plugins/my-plugin/*
 ```bash
 # プロジェクトルートで実行
 uvx pytest scripts/tests/ -v
+
+# カバレッジ付きで実行
+uvx --with pytest-cov pytest scripts/tests/ -v --cov=scripts/validators --cov-report=term
 ```
 
 ### venvを使用する場合

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
+    "pytest-cov>=6.0.0",
 ]
 
 [tool.pytest.ini_options]
@@ -16,3 +17,15 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+
+[tool.coverage.run]
+source = ["validators"]
+omit = ["tests/*", "*/__init__.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+fail_under = 80


### PR DESCRIPTION
## Summary

- pytest-covを導入し、テストカバレッジを計測・可視化
- GitHub Actions完結でバッジを更新（Gist + shields.io）
- カバレッジ閾値80%でCIをfailさせる設定

## 変更内容

### 追加・変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `scripts/pyproject.toml` | pytest-cov追加、coverage設定（fail_under=80） |
| `.github/workflows/test-scripts.yml` | カバレッジ計測・レポート・バッジ更新 |
| `README.md` | カバレッジバッジ追加、セットアップ手順追加 |
| `CLAUDE.md` | カバレッジ付きテストコマンド追加 |
| `scripts/README.md` | カバレッジ付きテストコマンド追加 |

### マージ後に必要な手順
1. [gist.github.com](https://gist.github.com)で`coverage.json`ファイルを含むGistを作成
2. [GitHub Settings > Tokens](https://github.com/settings/tokens)で`gist`スコープのPATを生成
3. リポジトリSettings > Secrets > `GIST_SECRET`にトークンを設定
4. リポジトリSettings > Variables > `COVERAGE_GIST_ID`にGist IDを設定
5. README.mdのバッジURLの`COVERAGE_GIST_ID`を実際のGist IDに置換

## ドキュメント整合性確認

| チェック項目 | 結果 |
|-------------|------|
| `.claude/rules/README.md`索引と実ファイル | ✅ 一致（10ドキュメント） |
| README.md / CLAUDE.md / scripts/README.md のテストコマンド | ✅ 統一済み |
| カバレッジコマンドの記載 | ✅ 3ドキュメントすべてに追加 |

## Test plan

- [ ] CIでテストが通ること
- [ ] カバレッジが80%以上であること
- [ ] カバレッジレポートがアーティファクトとして保存されること
- [ ] Gist設定後、バッジが正しく表示されること

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)