### PR TITLE
ci: ワークフローにタイムアウト設定を追加

### DIFF
--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   monitor-changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
   python-lint:
     name: Python (Ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4
@@ -42,6 +43,7 @@ jobs:
   yaml-lint:
     name: YAML (yamllint)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4
@@ -55,6 +57,7 @@ jobs:
   markdown-lint:
     name: Markdown (markdownlint)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,6 +9,7 @@ jobs:
   secret-scan:
     name: シークレットスキャン
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- 全7ワークフロー（9ジョブ）に `timeout-minutes` を設定
- ハング時のリソース消費を防止

### 設定値

| ワークフロー | ジョブ | timeout-minutes |
|-------------|-------|-----------------|
| test-scripts.yml | test | 10 |
| lint.yml | python-lint | 5 |
| lint.yml | yaml-lint | 5 |
| lint.yml | markdown-lint | 5 |
| security-scan.yml | secret-scan | 5 |
| validate-plugins.yml | validate | 10 |
| changelog-monitor.yml | monitor-changelog | 20 |
| claude-code-review.yml | claude-review | 20 |
| claude.yml | claude | 20 |

Claude関連ワークフローは LLM 呼び出しを含むため、20分に設定。

## Test plan

- [x] yamllint でYAML構文エラーがないことを確認

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)