### PR TITLE
refactor(validators): JSONパースのエラーハンドリング共通化

### DIFF
--- a/scripts/validators/__init__.py
+++ b/scripts/validators/__init__.py
@@ -3,7 +3,7 @@
 """
 
 from .agent import validate_agent
-from .base import ValidationResult, parse_frontmatter
+from .base import ValidationResult, parse_frontmatter, parse_json_safe
 from .hooks_json import validate_hooks_json
 from .lsp_json import validate_lsp_json
 from .mcp_json import validate_mcp_json
@@ -16,6 +16,7 @@ from .slash_command import validate_slash_command
 __all__ = [
     "ValidationResult",
     "parse_frontmatter",
+    "parse_json_safe",
     "validate_slash_command",
     "validate_agent",
     "validate_skill",

--- a/scripts/validators/base.py
+++ b/scripts/validators/base.py
@@ -2,6 +2,7 @@
 共通ユーティリティ: ValidationResult と parse_frontmatter
 """
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -179,3 +180,22 @@ def check_env_secrets(
                     f"{file_path.name}: {context_name}: "
                     f"envの{key}に機密情報の可能性。${{{{VAR}}}}形式を使用"
                 )
+
+
+def parse_json_safe(content: str, file_path: Path, result: ValidationResult) -> dict | None:
+    """
+    JSON文字列を安全にパースする
+
+    Args:
+        content: JSON文字列
+        file_path: エラーメッセージ用のファイルパス
+        result: 検証結果オブジェクト
+
+    Returns:
+        パース成功時はdict、失敗時はNone（resultにエラーを追加）
+    """
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        result.add_error(f"{file_path.name}: JSONパースエラー: {e}")
+        return None

--- a/scripts/validators/hooks_json.py
+++ b/scripts/validators/hooks_json.py
@@ -2,20 +2,17 @@
 hooks.json のバリデーター
 """
 
-import json
 from pathlib import Path
 
-from .base import ValidationResult
+from .base import ValidationResult, parse_json_safe
 
 
 def validate_hooks_json(file_path: Path, content: str) -> ValidationResult:
     """hooks.jsonを検証する"""
     result = ValidationResult()
 
-    try:
-        data = json.loads(content)
-    except json.JSONDecodeError as e:
-        result.add_error(f"{file_path.name}: JSONパースエラー: {e}")
+    data = parse_json_safe(content, file_path, result)
+    if data is None:
         return result
 
     hooks = data.get("hooks", {})

--- a/scripts/validators/lsp_json.py
+++ b/scripts/validators/lsp_json.py
@@ -2,10 +2,9 @@
 .lsp.json のバリデーター
 """
 
-import json
 from pathlib import Path
 
-from .base import ValidationResult, check_env_secrets
+from .base import ValidationResult, check_env_secrets, parse_json_safe
 
 # 有効なtransport値
 VALID_TRANSPORTS = {"stdio", "socket"}
@@ -15,10 +14,8 @@ def validate_lsp_json(file_path: Path, content: str) -> ValidationResult:
     """LSPサーバー設定を検証する"""
     result = ValidationResult()
 
-    try:
-        data = json.loads(content)
-    except json.JSONDecodeError as e:
-        result.add_error(f"{file_path.name}: JSONパースエラー: {e}")
+    data = parse_json_safe(content, file_path, result)
+    if data is None:
         return result
 
     if not data:

--- a/scripts/validators/mcp_json.py
+++ b/scripts/validators/mcp_json.py
@@ -2,20 +2,17 @@
 .mcp.json のバリデーター
 """
 
-import json
 from pathlib import Path
 
-from .base import ValidationResult, check_env_secrets
+from .base import ValidationResult, check_env_secrets, parse_json_safe
 
 
 def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
     """MCPサーバー設定を検証する"""
     result = ValidationResult()
 
-    try:
-        data = json.loads(content)
-    except json.JSONDecodeError as e:
-        result.add_error(f"{file_path.name}: JSONパースエラー: {e}")
+    data = parse_json_safe(content, file_path, result)
+    if data is None:
         return result
 
     servers = data.get("mcpServers", {})

--- a/scripts/validators/plugin_json.py
+++ b/scripts/validators/plugin_json.py
@@ -2,21 +2,18 @@
 plugin.json のバリデーター
 """
 
-import json
 import re
 from pathlib import Path
 
-from .base import ValidationResult, validate_kebab_case
+from .base import ValidationResult, parse_json_safe, validate_kebab_case
 
 
 def validate_plugin_json(file_path: Path, content: str) -> ValidationResult:
     """plugin.jsonを検証する"""
     result = ValidationResult()
 
-    try:
-        data = json.loads(content)
-    except json.JSONDecodeError as e:
-        result.add_error(f"{file_path.name}: JSONパースエラー: {e}")
+    data = parse_json_safe(content, file_path, result)
+    if data is None:
         return result
 
     # 必須フィールド


### PR DESCRIPTION
## Summary

- 4つのJSONバリデーター（plugin_json, hooks_json, mcp_json, lsp_json）で重複していたJSONパースのエラーハンドリングを`parse_json_safe`関数として共通化
- DRY原則に従い、エラーメッセージの一元管理により保守性を向上

## 変更内容

| ファイル | 変更 |
|----------|------|
| `base.py` | `parse_json_safe`関数を追加 |
| `plugin_json.py` | 共通関数を使用、`import json`削除 |
| `hooks_json.py` | 同上 |
| `mcp_json.py` | 同上 |
| `lsp_json.py` | 同上 |
| `__init__.py` | `parse_json_safe`をエクスポートに追加 |

## Test plan

- [x] `uvx pytest scripts/tests/ -v` - 150件全テスト通過
- [x] `uvx ruff check scripts/` - 通過
- [x] `uvx ruff format scripts/ --check` - 通過

closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)