### PR TITLE
fix: マーケットプレイス名を予約済み名から変更

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-marketplace",
+  "name": "custom-marketplace",
   "owner": {
     "name": "rfdnxbro"
   },


### PR DESCRIPTION
## Summary
- `claude-code-marketplace`はAnthropic公式マーケットプレイス用に予約されているため、`custom-marketplace`に名前を変更

## Test plan
- [ ] `claude plugin validate .` でエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)