### PR TITLE
fix(ai-dlc): 冗長なデフォルトパス指定を削除

### DIFF
--- a/plugins/ai-dlc/.claude-plugin/plugin.json
+++ b/plugins/ai-dlc/.claude-plugin/plugin.json
@@ -7,8 +7,5 @@
   },
   "repository": "https://github.com/rfdnxbro/claude-code-marketplace",
   "license": "MIT",
-  "keywords": ["ai-dlc", "sdlc", "agile", "ddd", "methodology"],
-  "commands": "./commands/",
-  "agents": "./agents/",
-  "skills": "./skills/"
+  "keywords": ["ai-dlc", "sdlc", "agile", "ddd", "methodology"]
 }


### PR DESCRIPTION
## Summary
- plugin.jsonからデフォルトディレクトリ（commands/, agents/, skills/）の明示的な指定を削除
- これらはClaude Codeが自動検出するため不要
- 「agents: Invalid input: must end with ".md"」バリデーションエラーを解消

## Test plan
- [ ] `claude /plugin` でプラグインがインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)