### PR TITLE
docs(plugin-manifest): デフォルトディレクトリの動作を追記

### DIFF
--- a/.claude/rules/plugin-manifest.md
+++ b/.claude/rules/plugin-manifest.md
@@ -28,15 +28,21 @@ paths: plugins/*/.claude-plugin/plugin.json, .claude-plugin/plugin.json
 
 ## コンポーネント参照
 
-| フィールド | 型 | 説明 |
-|-----------|---|------|
-| `commands` | string/array | コマンドファイル/ディレクトリ |
-| `agents` | string/array | エージェントファイル/ディレクトリ |
-| `skills` | string/array | スキルディレクトリ |
-| `hooks` | string/object | フック設定パスまたはインライン |
-| `mcpServers` | string/object | MCP設定パスまたはインライン（→ [mcp-servers.md](mcp-servers.md)） |
-| `lspServers` | string/object | LSP設定パスまたはインライン（→ [lsp-servers.md](lsp-servers.md)） |
-| `outputStyles` | string/array | 出力スタイルファイル/ディレクトリ（→ [output-styles.md](output-styles.md)） |
+| フィールド | 型 | 説明 | デフォルトディレクトリ |
+|-----------|---|------|----------------------|
+| `commands` | string/array | コマンドファイル/ディレクトリ | `commands/` |
+| `agents` | string/array | エージェントファイル/ディレクトリ | `agents/` |
+| `skills` | string/array | スキルディレクトリ | `skills/` |
+| `hooks` | string/object | フック設定パスまたはインライン | `hooks/hooks.json` |
+| `mcpServers` | string/object | MCP設定パスまたはインライン（→ [mcp-servers.md](mcp-servers.md)） | `.mcp.json` |
+| `lspServers` | string/object | LSP設定パスまたはインライン（→ [lsp-servers.md](lsp-servers.md)） | `.lsp.json` |
+| `outputStyles` | string/array | 出力スタイルファイル/ディレクトリ（→ [output-styles.md](output-styles.md)） | なし |
+
+**デフォルトディレクトリの動作**:
+
+- デフォルトディレクトリ（`commands/`, `agents/`, `skills/`等）が存在すれば自動的に読み込まれる
+- plugin.jsonでの明示的な指定は不要
+- カスタムパスを指定した場合、デフォルトディレクトリと**両方が読み込まれる**（置き換えではなく補足）
 
 ## 完全な例
 


### PR DESCRIPTION
## Summary

- plugin-manifest.mdのコンポーネント参照テーブルにデフォルトディレクトリ列を追加
- `commands/`, `agents/`, `skills/`等は存在すれば自動読み込みされることを明記
- カスタムパス指定時の動作（補足であり置き換えではない）を説明

## 関連

- Closes #51 のフォローアップ（Stop hookフィードバック対応）

## Test plan

- [ ] markdownlintでlintエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)