### PR TITLE
fix: changelog-monitorワークフローのallowed_tools指定方法を修正

### DIFF
--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -98,6 +98,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # yamllint disable-line rule:line-length
+          allowed_tools: 'Bash(gh issue create:*),Bash(gh issue list:*),Read,Grep,Glob'
+          max_turns: 20
           prompt: |
             あなたはClaude Codeマーケットプレイスのメンテナーです。
 
@@ -134,8 +137,7 @@ jobs:
             - Issueタイトルは「[CHANGELOG vX.X.X] 」で始める形式にする
             - 不明確な変更は「要確認」としてマーク
             - ラベル claude-code-update は必ず付与する（これにより自動実装CIがトリガーされる）
-          # yamllint disable-line rule:line-length
-          claude_args: '--allowed-tools "Bash(gh issue create:*),Bash(gh issue list:*),Read,Grep,Glob"'
+            - gh issue create が失敗した場合は、エラーメッセージを確認して対処する
 
       - name: スナップショットを更新
         if: steps.claude-analysis.outcome == 'success'


### PR DESCRIPTION
## Summary
- claude_argsからallowed_toolsパラメータへ変更（claude-code-action v1の推奨方式）
- max_turns: 20を追加して処理完了を確保
- エラー対処の指示をプロンプトに追加

## 修正内容
GitHub Actions run #20870391155 で発生したエラーを修正します。

エラー原因: `claude_args`経由での`--allowed-tools`指定がSDK内で正しく処理されず、`error_during_execution`が発生していました。

修正: `allowed_tools`パラメータを直接使用するように変更。

## Test plan
- [ ] ワークフローを手動実行して成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)