### PR TITLE
fix: claude_argsで--allowedToolsフラグを使用するよう修正

### DIFF
--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -98,9 +98,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # yamllint disable-line rule:line-length
-          allowed_tools: 'Bash(gh issue create:*),Bash(gh issue list:*),Read,Grep,Glob'
           max_turns: 20
+          # yamllint disable-line rule:line-length
+          claude_args: '--allowedTools "Bash(gh issue create:*),Bash(gh issue list:*),Read,Grep,Glob"'
           prompt: |
             あなたはClaude Codeマーケットプレイスのメンテナーです。
 


### PR DESCRIPTION
## Summary
- `allowed_tools`パラメータから`claude_args`の`--allowedTools`フラグに変更

## 修正内容
前回のPR #88 で`allowed_tools`パラメータを使用するよう変更しましたが、SDKがこのパラメータを認識していませんでした。

ログ確認結果:
```
SDK options: {
  "systemPrompt": { ... },
  // allowedTools が含まれていない!
}
```

そして`permission_denials`でBashツールが拒否されていました。

公式ドキュメントによると、`claude_args`で`--allowedTools`フラグを使用する方式が推奨されています。

## Test plan
- [ ] ワークフローを手動実行して成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)