### PR TITLE
fix: auto-implementワークフローのgit push認証エラーを修正

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: シークレット検証
         run: |


### PR DESCRIPTION
## 概要
auto-implementワークフローでgit pushが失敗する問題を修正します。

## 修正内容
`actions/checkout@v6`に`token`パラメータを明示的に指定し、git push時の認証情報が正しく設定されるようにしました。

## 関連
- https://github.com/rfdnxbro/claude-code-marketplace/actions/runs/20871697052

🤖 Generated with [Claude Code](https://claude.com/claude-code)