### PR TITLE
fix: auto-implementワークフローのgit push認証を修正

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -133,12 +133,21 @@ jobs:
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
 
+          # デバッグ情報を出力
+          echo "=== デバッグ情報 ==="
+          echo "ブランチ名: ${{ steps.branch.outputs.name }}"
+          git remote -v
+          echo "==================="
+
+          # 明示的にトークンを使用してリモートURLを設定
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
           if ! git push -u origin ${{ steps.branch.outputs.name }}; then
             echo "::error::git push に失敗しました"
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PRを作成
         if: steps.check-changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary
- auto-implementワークフローでgit pushが失敗する問題を修正
- 明示的に`x-access-token`形式でリモートURLを設定するよう変更
- デバッグ情報を追加して次回問題発生時の調査を容易に

## 変更内容
- `git remote set-url`で明示的にトークン認証を設定
- 環境変数名を`GH_TOKEN`から`GITHUB_TOKEN`に変更（git認証で使用するため）
- ブランチ名とリモート情報のデバッグ出力を追加

## Test plan
- [ ] claude-code-updateラベルを付けたIssueでワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)