### PR TITLE
fix: git pushでforce pushを使用してブランチ競合を回避

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -41,11 +41,10 @@ jobs:
           BRANCH_NAME="auto/claude-code-update-issue-${{ github.event.issue.number }}"
           echo "name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
-          # ブランチが既に存在する場合は削除して再作成
+          # ローカルブランチが既に存在する場合は削除
           if git rev-parse --verify "${BRANCH_NAME}" >/dev/null 2>&1; then
-            echo "既存ブランチを削除します: ${BRANCH_NAME}"
+            echo "既存ローカルブランチを削除します: ${BRANCH_NAME}"
             git branch -D "${BRANCH_NAME}" || true
-            git push origin --delete "${BRANCH_NAME}" || true
           fi
 
           git checkout -b "${BRANCH_NAME}"
@@ -143,7 +142,8 @@ jobs:
           # 明示的にトークンを使用してリモートURLを設定
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
-          if ! git push -u origin ${{ steps.branch.outputs.name }}; then
+          # 前回の実行でブランチが残っている場合があるためforce push
+          if ! git push -u --force origin ${{ steps.branch.outputs.name }}; then
             echo "::error::git push に失敗しました"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- `git push`に`--force`オプションを追加
- 前回の実行でリモートにブランチが残っている場合のnon-fast-forwardエラーを回避

## 背景
Issue #82 の再実行時に以下のエラーが発生:
```
! [rejected] auto/claude-code-update-issue-82 -> auto/claude-code-update-issue-82 (non-fast-forward)
```

## セキュリティ考慮
- 対象は`auto/claude-code-update-issue-*`という専用ブランチのみ
- 他のブランチへの影響なし

## Test plan
- [ ] Issue #82 に再度`claude-code-update`ラベルを付けて動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)