### PR TITLE
fix: plugin-update用のallowed-toolsにvalidate_plugin.pyを追加

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -170,7 +170,8 @@ jobs:
             - リポジトリに永続的に必要なファイルのみ作成・変更すること
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
-          claude_args: '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx pytest*)"'
+          # yamllint disable-line rule:line-length
+          claude_args: '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx pytest*),Bash(python3 scripts/validate_plugin.py*)"'
 
       - name: 変更があるか確認
         id: check-changes


### PR DESCRIPTION
## 概要
`auto-implement.yml` の `plugin-update` 用 Claude Code Action で、プラグイン検証スクリプトの実行を許可します。

## 問題
Issue #101 の自動実装時に、Claude が `python3 scripts/validate_plugin.py` を実行しようとして権限拒否エラーが発生していました。

## 修正内容
`allowed-tools` に `Bash(python3 scripts/validate_plugin.py*)` を追加。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)