### PR TITLE
fix: auto-implementのmax_turnsを50に増加

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -88,6 +88,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          max_turns: 50
           prompt: |
             あなたはClaude Codeマーケットプレイスのソフトウェアエンジニアです。
 
@@ -137,6 +138,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          max_turns: 50
           prompt: |
             あなたはClaude Codeマーケットプレイスのソフトウェアエンジニアです。
 


### PR DESCRIPTION
## 概要
Issue #101の自動実装が26ターンで`error_during_execution`になった問題への対策。

## 変更内容
- `claude-code-update`用ステップに`max_turns: 50`を追加
- `plugin-update`用ステップに`max_turns: 50`を追加

## 背景
Issue #101は5つの改善項目を含んでおり、デフォルトのターン数では不足していた可能性がある。

## 関連
- Issue #101

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)