### PR TITLE
fix: plugin-update用のallowed-toolsを緩和

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -171,7 +171,7 @@ jobs:
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
           # yamllint disable-line rule:line-length
-          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx pytest*),Bash(python3 scripts/validate_plugin.py*)"'
+          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *)"'
 
       - name: 変更があるか確認
         id: check-changes


### PR DESCRIPTION
## Summary
- plugin-update CIジョブでのallowed-toolsを緩和
- `Bash(uvx *)`, `Bash(python3 scripts/*)`, `Bash(npx *)` を許可

## 背景
Issue #101の自動実装CIが失敗していた。
https://github.com/rfdnxbro/claude-code-marketplace/actions/runs/20877766795/job/59989603536

原因として、allowed-toolsの制限が厳しく、必要なBashコマンド（uvx ruff, uvx yamllint, npx markdownlint等）が実行できなかった可能性がある。

## 変更内容
```diff
-claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx pytest*),Bash(python3 scripts/validate_plugin.py*)"'
+claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *)"'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)