### PR TITLE
fix: PR作成時にラベルが存在しない場合は自動作成する

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -225,6 +225,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: ラベルが存在しない場合は作成
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          # PRに付与するラベルが存在するか確認し、なければ作成
+          for LABEL in "${{ github.event.label.name }}" "${{ steps.config.outputs.pr_label }}"; do
+            if ! gh label list --json name --jq '.[].name' | grep -q "^${LABEL}$"; then
+              echo "ラベル '${LABEL}' が存在しないため作成します"
+              gh label create "${LABEL}" --description "自動生成されたラベル" || true
+            else
+              echo "ラベル '${LABEL}' は既に存在します"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: PRを作成
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
## Summary
- auto-implement.ymlでPR作成時、指定されたラベルが存在しない場合に自動作成するステップを追加
- `plugin-update`ラベルでトリガーされた際に`plugin`ラベルが存在しないとPR作成が失敗する問題を修正

## 原因
https://github.com/rfdnxbro/claude-code-marketplace/actions/runs/20877766795 で発生したエラー：
```
could not add label: 'plugin' not found
```

## 変更内容
PR作成ステップの直前に、ラベルの存在確認・作成を行う新しいステップを追加：
- PRに付与する2つのラベルを確認
- 存在しない場合は`gh label create`で自動作成

## Test plan
- [ ] `plugin-update`ラベルをIssueに付与してワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)