### PR TITLE
fix: auto-implementで一時ファイルがコミットに含まれる問題を修正

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -189,6 +189,8 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |
           set -e
+          # 一時ファイルを削除（コミットに含めないため）
+          rm -f issue-body.md issue-title.txt
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -A


### PR DESCRIPTION
## Summary
- auto-implementワークフローで作成される一時ファイル（`issue-body.md`, `issue-title.txt`）がPRに含まれてしまう問題を修正
- `git add -A` の前に一時ファイルを削除するようにした

## Test plan
- [ ] plugin-updateラベルを付けたIssueで自動実装を実行し、PRに一時ファイルが含まれないことを確認

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)