### PR TITLE
fix: plugin-improvement-checkのmax-turnsを50に増加

### DIFF
--- a/.github/workflows/plugin-improvement-check.yml
+++ b/.github/workflows/plugin-improvement-check.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # yamllint disable-line rule:line-length
-          claude_args: '--max-turns 30 --allowed-tools "Read,Grep,Glob,Bash(gh issue create:*),Bash(gh issue list:*)"'
+          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Bash(gh issue create:*),Bash(gh issue list:*)"'
           prompt: |
             あなたはClaude Codeマーケットプレイスのメンテナーです。
 


### PR DESCRIPTION
## Summary
- plugin-improvement-checkワークフローの`--max-turns`を30から50に増加
- error_max_turnsエラー（30ターンでタスク完了不可）への対応

## Test plan
- [ ] workflow_dispatchで手動実行し、タスクが完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)