### PR TITLE
feat: marketplace.jsonにbblプラグインを追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,8 +14,28 @@
       "source": "./plugins/ai-dlc",
       "description": "AI駆動開発ライフサイクル（AI-DLC）のスラッシュコマンド、サブエージェント、スキルを提供するプラグイン",
       "version": "0.1.0",
-      "keywords": ["ai-dlc", "sdlc", "agile", "ddd", "methodology"],
+      "keywords": [
+        "ai-dlc",
+        "sdlc",
+        "agile",
+        "ddd",
+        "methodology"
+      ],
       "category": "methodology"
+    },
+    {
+      "name": "bbl",
+      "source": "./plugins/bbl",
+      "description": "ビジネス基礎知識学習教材の記事作成を支援するプラグイン",
+      "version": "0.1.0",
+      "keywords": [
+        "business",
+        "learning",
+        "education",
+        "content",
+        "article"
+      ],
+      "category": "education"
     }
   ]
 }


### PR DESCRIPTION
## 概要

ビジネス基礎知識学習教材の記事作成を支援するbblプラグインをマーケットプレイスに追加します。

## 変更内容

- `.claude-plugin/marketplace.json`にbblプラグインのエントリを追加
- プラグイン情報:
  - 名前: `bbl`
  - ソース: `./plugins/bbl`
  - カテゴリ: `education`
  - キーワード: business, learning, education, content, article

## セキュリティレビュー

- ✅ 脆弱性なし
- ✅ パストラバーサルのリスクなし
- ✅ 機密情報なし
- ✅ インジェクション脆弱性なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)