### PR TITLE
fix: claude-code-actionにallowed_botsパラメータを追加

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -87,6 +87,7 @@ jobs:
         id: claude-implement-docs
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: 'claude'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             あなたはClaude Codeマーケットプレイスのソフトウェアエンジニアです。
@@ -139,6 +140,7 @@ jobs:
         id: claude-implement-plugin
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: 'claude'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             あなたはClaude Codeマーケットプレイスのソフトウェアエンジニアです。


### PR DESCRIPTION
## Summary
- claudeボットによるワークフロー起動時の「Workflow initiated by non-human actor」エラーを修正
- `claude-code-action`の両ステップに`allowed_bots: 'claude'`を追加

## 原因
`anthropics/claude-code-action`はデフォルトでボットからのワークフロー起動を拒否する仕様。
https://github.com/rfdnxbro/claude-code-marketplace/actions/runs/21086571255 で発生したエラーに対応。

## Test plan
- [ ] `claude-code-update`ラベル付与時のワークフローが正常に動作することを確認
- [ ] `plugin-update`ラベル付与時のワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)