### PR TITLE
docs: slash-commands.mdに${CLAUDE_SESSION_ID}を追加

### DIFF
--- a/.claude/rules/slash-commands.md
+++ b/.claude/rules/slash-commands.md
@@ -46,10 +46,11 @@ $ARGUMENTS で引数を受け取れます
 | `context` | No | 実行コンテキスト（`main`, `fork`） | `main` |
 | `hooks` | No | フック定義（[hooks.md](hooks.md)参照） | なし |
 
-## 引数
+## 引数と環境変数
 
 - `$ARGUMENTS` - 全ての引数をキャプチャ
 - `$1`, `$2`, `$3`... - 個別の位置指定引数
+- `${CLAUDE_SESSION_ID}` - 現在のセッションID（v2.1.9以降）
 
 ## allowed-tools のベストプラクティス
 


### PR DESCRIPTION
## Summary
- slash-commands.mdの引数セクションに`${CLAUDE_SESSION_ID}`環境変数を追加
- README.mdの環境変数リファレンスとの整合性を修正

## Test plan
- [x] markdownlintでエラーなし
- [x] README.md、skill-authoring.md、slash-commands.mdの3ファイルで整合性確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)