### PR TITLE
fix: plugin.jsonから非サポートのcategoryフィールドを削除

### DIFF
--- a/plugins/doc-check/.claude-plugin/plugin.json
+++ b/plugins/doc-check/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
   "homepage": "https://github.com/rfdnxbro/claude-code-marketplace/tree/main/plugins/doc-check",
   "repository": "https://github.com/rfdnxbro/claude-code-marketplace",
   "license": "MIT",
-  "keywords": ["documentation", "consistency", "check"],
-  "category": "quality"
+  "keywords": ["documentation", "consistency", "check"]
 }


### PR DESCRIPTION
## Summary

- doc-checkプラグインの`plugin.json`から、Claude Code本体が認識しない`category`フィールドを削除
- 公式ドキュメント（code.claude.com）で確認し、`category`は`marketplace.json`のプラグインエントリでのみサポートされていることを確認
- `marketplace.json`内の`category`フィールドは公式サポート済みのため変更なし

## Test plan

- [ ] `plugins/doc-check`がバリデーションエラーなくインストールできることを確認
- [ ] `pre-commit`のバリデーションが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
