### PR TITLE
Fix session-end hook to use SessionEnd event and log session metadata

### DIFF
--- a/plugins/bbl/hooks/hooks.json
+++ b/plugins/bbl/hooks/hooks.json
@@ -26,7 +26,7 @@
         ]
       }
     ],
-    "Stop": [
+    "SessionEnd": [
       {
         "hooks": [
           {

--- a/plugins/bbl/hooks/session-end.sh
+++ b/plugins/bbl/hooks/session-end.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# セッション終了時に最後のアシスタントメッセージをログに記録
+# セッション終了時にセッション情報をログに記録
+# 注意: SessionEndイベントではlast_assistant_messageは利用不可（Stop/SubagentStop専用）
+# 代わりにsession_idとtranscript_pathを記録する
 
 input=$(cat)
-last_message=$(echo "$input" | jq -r '.last_assistant_message // ""')
+session_id=$(echo "$input" | jq -r '.session_id // ""')
+transcript_path=$(echo "$input" | jq -r '.transcript_path // ""')
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-if [ -n "$last_message" ]; then
-  echo "$timestamp $last_message" >> "${CLAUDE_PROJECT_DIR}/.bbl-session.log"
+if [ -n "$session_id" ]; then
+  echo "$timestamp session_end session_id=$session_id transcript=$transcript_path" >> "${CLAUDE_PROJECT_DIR}/.bbl-session.log"
 fi


### PR DESCRIPTION
## Summary
Updated the session-end hook to properly use the `SessionEnd` event instead of `Stop`, and changed the logged information from `last_assistant_message` (which is unavailable in SessionEnd) to session metadata (`session_id` and `transcript_path`).

## Key Changes
- Changed hook trigger from `Stop` to `SessionEnd` event in hooks.json
- Updated session-end.sh to extract `session_id` and `transcript_path` instead of `last_assistant_message`
- Modified log format to include session metadata: `timestamp session_end session_id=<id> transcript=<path>`
- Added clarifying comments explaining that `last_assistant_message` is only available in Stop/SubagentStop events, not SessionEnd

## Implementation Details
The hook now logs structured session information when a session ends, making it easier to track session lifecycle and correlate logs with transcript files. The log format follows a consistent pattern with timestamp, event type, and key-value pairs for session metadata.

https://claude.ai/code/session_01M4fLm5dheJ6gkFV32Gy1Dk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
