### PR TITLE
chore: code-reviewとcommit-commandsプラグインを有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,9 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- `claude-plugins-official`の`code-review`および`commit-commands`プラグインを`enabledPlugins`に追加

## Test plan
- [ ] `.claude/settings.json`のJSON構文が正しいことを確認
- [ ] プラグインが正常にロードされることを確認（`/reload-plugins`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
