### PR TITLE
chore: settings.jsonにlanguage設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
       }
     ]
   },
+  "language": "関西弁",
   "enabledPlugins": {
     "code-review@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true


### PR DESCRIPTION
## Summary
- `.claude/settings.json`に`language: "関西弁"`を追加
- Claude Code on the Web環境でsettings.jsonのlanguage設定が反映されるかの検証用PR

## Test plan
- [ ] Claude Code on the Web環境でこのリポジトリを開き、応答が関西弁になるか確認する
- [ ] 検証完了後、設定を元に戻すかどうか判断する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
