### PR TITLE
chore: Web環境でのhookイベント動作検証

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,6 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -24,7 +23,6 @@
         ]
       },
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -36,7 +34,6 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -48,7 +45,6 @@
     ],
     "PermissionRequest": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -71,7 +67,6 @@
     ],
     "Notification": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -94,7 +89,6 @@
     ],
     "SubagentStart": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -106,7 +100,6 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -118,7 +111,6 @@
     ],
     "PreCompact": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -130,7 +122,6 @@
     ],
     "PostCompact": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -142,7 +133,6 @@
     ],
     "SessionStart": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -198,7 +188,6 @@
     ],
     "ConfigChange": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -243,7 +232,6 @@
     ],
     "Elicitation": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -255,7 +243,6 @@
     ],
     "ElicitationResult": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/scripts/debug-hook.sh
+++ b/scripts/debug-hook.sh
@@ -13,8 +13,8 @@ if command -v jq &> /dev/null; then
   tool_name=$(echo "$input" | jq -r '.tool_name // ""')
   session_id=$(echo "$input" | jq -r '.session_id // ""' | head -c 8)
 else
-  hook_event=$(echo "$input" | grep -o '"hook_event_name":"[^"]*"' | cut -d'"' -f4)
-  tool_name=$(echo "$input" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+  hook_event=$(echo "$input" | grep -oE '"hook_event_name"\s*:\s*"[^"]*"' | cut -d'"' -f4)
+  tool_name=$(echo "$input" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | cut -d'"' -f4)
   session_id="n/a"
 fi
 


### PR DESCRIPTION
## Summary
- 全22種のhookイベントにデバッグ用ログ出力を`.claude/settings.json`に設定
- `scripts/debug-hook.sh`を追加し、各hookイベント発火時にタイムスタンプ・イベント名・ツール名をログ出力
- ログ出力先: `/tmp/claude-hook-debug.log`

## 対象hookイベント（22種）

| カテゴリ | イベント |
|---------|---------|
| ツール関連 | `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest` |
| ユーザー入力 | `UserPromptSubmit` |
| 通知 | `Notification` |
| エージェント/停止 | `Stop`, `SubagentStart`, `SubagentStop` |
| コンパクション | `PreCompact`, `PostCompact` |
| セッション | `SessionStart`, `SessionEnd` |
| セットアップ | `Setup` |
| マルチエージェント | `TeammateIdle`, `TaskCompleted` |
| 設定変更 | `ConfigChange` |
| Worktree | `WorktreeCreate`, `WorktreeRemove` |
| 指示読込 | `InstructionsLoaded` |
| MCPエリシテーション | `Elicitation`, `ElicitationResult` |

## 検証方法
1. Web環境（claude.ai/code）でこのリポジトリを開く
2. 通常の操作（ツール実行、プロンプト送信など）を行う
3. `/tmp/claude-hook-debug.log` の内容を確認し、どのhookが発火したか確認

```bash
cat /tmp/claude-hook-debug.log
```

## Test plan
- [ ] Web環境でセッション開始し、`SessionStart`が記録されるか確認
- [ ] ツール実行時に`PreToolUse`/`PostToolUse`が記録されるか確認
- [ ] プロンプト送信時に`UserPromptSubmit`が記録されるか確認
- [ ] セッション終了時に`SessionEnd`/`Stop`が記録されるか確認
- [ ] 発火しなかったイベントを一覧化し、Web環境の制約を把握

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
