### PR TITLE
Refactor: Extract common validation helpers into reusable functions

### DIFF
--- a/scripts/tests/test_base.py
+++ b/scripts/tests/test_base.py
@@ -2,9 +2,22 @@
 base.py のテスト
 """
 
+from pathlib import Path
 from textwrap import dedent
 
-from scripts.validators.base import ValidationResult, normalize_path, parse_frontmatter
+from scripts.validators.base import (
+    WARNING_BROAD_BASH_WILDCARD,
+    ValidationResult,
+    add_yaml_warnings,
+    normalize_path,
+    parse_frontmatter,
+    to_str,
+    validate_agent_field,
+    validate_allowed_tools,
+    validate_context_field,
+    validate_effort_field,
+    validate_string_or_list_field,
+)
 
 
 class TestValidationResult:
@@ -187,6 +200,181 @@ class TestParseFrontmatter:
         """).strip()
         fm, body, warnings = parse_frontmatter(content)
         assert any("ネスト" in w for w in warnings)
+
+
+class TestToStr:
+    """to_strのテスト"""
+
+    def test_none(self):
+        assert to_str(None) == ""
+
+    def test_empty_string(self):
+        assert to_str("") == ""
+
+    def test_zero(self):
+        assert to_str(0) == ""
+
+    def test_false(self):
+        assert to_str(False) == ""
+
+    def test_normal_string(self):
+        assert to_str("hello") == "hello"
+
+    def test_integer(self):
+        assert to_str(42) == "42"
+
+    def test_true(self):
+        assert to_str(True) == "True"
+
+
+class TestAddYamlWarnings:
+    """add_yaml_warningsのテスト"""
+
+    def test_empty_warnings(self):
+        result = ValidationResult()
+        add_yaml_warnings(result, Path("test.md"), [])
+        assert result.warnings == []
+
+    def test_multiple_warnings(self):
+        result = ValidationResult()
+        add_yaml_warnings(result, Path("test.md"), ["警告1", "警告2"])
+        assert len(result.warnings) == 2
+        assert "test.md: 警告1" in result.warnings[0]
+        assert "test.md: 警告2" in result.warnings[1]
+
+
+class TestValidateContextField:
+    """validate_context_fieldのテスト"""
+
+    def test_not_specified(self):
+        result = ValidationResult()
+        validate_context_field(result, Path("test.md"), {})
+        assert not result.has_errors()
+
+    def test_fork_valid(self):
+        result = ValidationResult()
+        validate_context_field(result, Path("test.md"), {"context": "fork"})
+        assert not result.has_errors()
+
+    def test_invalid_value(self):
+        result = ValidationResult()
+        validate_context_field(result, Path("test.md"), {"context": "invalid"})
+        assert result.has_errors()
+        assert any("context" in e for e in result.errors)
+
+
+class TestValidateAgentField:
+    """validate_agent_fieldのテスト"""
+
+    def test_not_specified(self):
+        result = ValidationResult()
+        validate_agent_field(result, Path("test.md"), {})
+        assert not result.has_errors()
+
+    def test_valid_agent(self):
+        result = ValidationResult()
+        validate_agent_field(result, Path("test.md"), {"agent": "my-agent"})
+        assert not result.has_errors()
+
+    def test_empty_agent(self):
+        result = ValidationResult()
+        validate_agent_field(result, Path("test.md"), {"agent": ""})
+        assert result.has_errors()
+        assert any("agent" in e for e in result.errors)
+
+
+class TestValidateAllowedTools:
+    """validate_allowed_toolsのテスト"""
+
+    def test_not_specified(self):
+        result = ValidationResult()
+        validate_allowed_tools(result, Path("test.md"), {}, set())
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
+
+    def test_list_format(self):
+        result = ValidationResult()
+        fm = {"allowed-tools": ["Read", "Write"]}
+        validate_allowed_tools(result, Path("test.md"), fm, set())
+        assert len(result.warnings) == 0
+
+    def test_bash_wildcard_warning(self):
+        result = ValidationResult()
+        fm = {"allowed-tools": "Bash(*)"}
+        validate_allowed_tools(result, Path("test.md"), fm, set())
+        assert any("Bash(*)" in w for w in result.warnings)
+
+    def test_bash_wildcard_disabled(self):
+        result = ValidationResult()
+        fm = {"allowed-tools": "Bash(*)"}
+        validate_allowed_tools(result, Path("test.md"), fm, {WARNING_BROAD_BASH_WILDCARD})
+        assert len(result.warnings) == 0
+
+
+class TestValidateEffortField:
+    """validate_effort_fieldのテスト"""
+
+    def test_not_specified(self):
+        result = ValidationResult()
+        validate_effort_field(result, Path("test.md"), {}, ["low", "normal", "high"])
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
+
+    def test_valid_value(self):
+        result = ValidationResult()
+        validate_effort_field(result, Path("test.md"), {"effort": "low"}, ["low", "normal", "high"])
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
+
+    def test_invalid_value_warning(self):
+        result = ValidationResult()
+        validate_effort_field(
+            result, Path("test.md"), {"effort": "ultra"}, ["low", "normal", "high"]
+        )
+        assert any("effort" in w for w in result.warnings)
+
+    def test_invalid_value_error(self):
+        result = ValidationResult()
+        validate_effort_field(
+            result,
+            Path("test.md"),
+            {"effort": "ultra"},
+            ["low", "medium", "high", "max"],
+            level="error",
+        )
+        assert result.has_errors()
+        assert any("effort" in e for e in result.errors)
+
+
+class TestValidateStringOrListField:
+    """validate_string_or_list_fieldのテスト"""
+
+    def test_none_value(self):
+        result = ValidationResult()
+        validate_string_or_list_field(result, Path("test.md"), "tools", None)
+        assert not result.has_errors()
+
+    def test_string_value(self):
+        result = ValidationResult()
+        validate_string_or_list_field(result, Path("test.md"), "tools", "Read, Write")
+        assert not result.has_errors()
+
+    def test_valid_list(self):
+        result = ValidationResult()
+        validate_string_or_list_field(result, Path("test.md"), "tools", ["Read", "Write"])
+        assert not result.has_errors()
+
+    def test_list_with_empty_item(self):
+        result = ValidationResult()
+        validate_string_or_list_field(result, Path("test.md"), "tools", ["Read", ""])
+        assert result.has_errors()
+        assert any("tools" in e for e in result.errors)
+
+    def test_invalid_type(self):
+        result = ValidationResult()
+        validate_string_or_list_field(result, Path("test.md"), "tools", 123)
+        assert result.has_errors()
+        assert any("文字列またはリスト" in e for e in result.errors)
 
 
 class TestNormalizePath:

--- a/scripts/validators/agent.py
+++ b/scripts/validators/agent.py
@@ -5,7 +5,15 @@
 import re
 from pathlib import Path
 
-from .base import ValidationResult, parse_frontmatter, validate_kebab_case
+from .base import (
+    ValidationResult,
+    add_yaml_warnings,
+    parse_frontmatter,
+    to_str,
+    validate_effort_field,
+    validate_kebab_case,
+    validate_string_or_list_field,
+)
 
 
 def _validate_task_syntax(tools_str: str) -> bool:
@@ -29,13 +37,11 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
     result = ValidationResult()
     frontmatter, body, yaml_warnings = parse_frontmatter(content)
 
-    # YAML警告を追加
-    for w in yaml_warnings:
-        result.add_warning(f"{file_path.name}: {w}")
+    add_yaml_warnings(result, file_path, yaml_warnings)
 
     # 必須フィールドの確認
     name = frontmatter.get("name", "")
-    name_str = str(name) if name else ""
+    name_str = to_str(name)
     if not name_str:
         result.add_error(f"{file_path.name}: nameが必須です")
     else:
@@ -46,7 +52,7 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
 
     # descriptionの確認
     description = frontmatter.get("description", "")
-    description_str = str(description) if description else ""
+    description_str = to_str(description)
     if not description_str:
         result.add_error(f"{file_path.name}: descriptionが必須です")
     elif len(description_str) < 20:
@@ -56,7 +62,7 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
 
     # modelの値チェック（v2.1.74以降: フルモデルIDも使用可能）
     model = frontmatter.get("model", "")
-    model_str = str(model) if model else ""
+    model_str = to_str(model)
     valid_shorthand_models = ["sonnet", "opus", "haiku", "inherit"]
     # フルモデルID（例: claude-opus-4-5, claude-sonnet-4-6, claude-haiku-4-5-20251001）のパターン
     full_model_id_pattern = re.compile(r"^claude-[a-z]+-[0-9][a-z0-9-]*$")
@@ -72,14 +78,14 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
 
     # permissionModeの値チェック
     permission_mode = frontmatter.get("permissionMode", "")
-    permission_mode_str = str(permission_mode) if permission_mode else ""
+    permission_mode_str = to_str(permission_mode)
     valid_modes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk", ""]
     if permission_mode_str and permission_mode_str not in valid_modes:
         result.add_error(f"{file_path.name}: permissionModeの値が不正です: {permission_mode_str}")
 
     # memoryの値チェック（v2.1.33以降）
     memory = frontmatter.get("memory", "")
-    memory_str = str(memory) if memory else ""
+    memory_str = to_str(memory)
     valid_memory_scopes = ["user", "project", "local", ""]
     if memory_str and memory_str not in valid_memory_scopes:
         result.add_error(
@@ -88,19 +94,20 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
 
     # isolationの値チェック（v2.1.50以降）
     isolation = frontmatter.get("isolation", "")
-    isolation_str = str(isolation) if isolation else ""
+    isolation_str = to_str(isolation)
     valid_isolation_modes = ["worktree", ""]
     if isolation_str and isolation_str not in valid_isolation_modes:
         result.add_error(f"{file_path.name}: isolationの値が不正です: {isolation_str}（worktree）")
 
     # effortの値チェック（v2.1.78以降）
-    effort = frontmatter.get("effort", "")
-    effort_str = str(effort) if effort else ""
-    valid_efforts = ["low", "medium", "high", "max", ""]
-    if effort_str and effort_str not in valid_efforts:
-        result.add_error(
-            f"{file_path.name}: effortの値が不正です: {effort_str}（low/medium/high/max）"
-        )
+    validate_effort_field(
+        result,
+        file_path,
+        frontmatter,
+        ["low", "medium", "high", "max"],
+        level="error",
+        hint="low/medium/high/max",
+    )
 
     # backgroundの値チェック（v2.1.49以降）
     background = frontmatter.get("background")
@@ -116,15 +123,9 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
 
     # toolsの確認（リスト形式検証）
     tools = frontmatter.get("tools")
+    validate_string_or_list_field(result, file_path, "tools", tools)
+    # Task(agent_type) 構文の検証
     if tools is not None:
-        if not isinstance(tools, (str, list)):
-            result.add_error(f"{file_path.name}: toolsは文字列またはリストが必要です")
-        elif isinstance(tools, list):
-            for t in tools:
-                if not isinstance(t, str) or not t:
-                    result.add_error(f"{file_path.name}: toolsの各要素は空でない文字列が必要です")
-                    break
-        # Task(agent_type) 構文の検証
         tools_str = (
             tools if isinstance(tools, str) else " ".join(tools) if isinstance(tools, list) else ""
         )
@@ -134,28 +135,12 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
             )
 
     # disallowedToolsの確認（リスト形式検証）
-    disallowed_tools = frontmatter.get("disallowedTools")
-    if disallowed_tools is not None:
-        if not isinstance(disallowed_tools, (str, list)):
-            result.add_error(f"{file_path.name}: disallowedToolsは文字列またはリストが必要です")
-        elif isinstance(disallowed_tools, list):
-            for t in disallowed_tools:
-                if not isinstance(t, str) or not t:
-                    result.add_error(
-                        f"{file_path.name}: disallowedToolsの各要素は空でない文字列が必要です"
-                    )
-                    break
+    validate_string_or_list_field(
+        result, file_path, "disallowedTools", frontmatter.get("disallowedTools")
+    )
 
     # skillsの確認（リスト形式検証）
-    skills = frontmatter.get("skills")
-    if skills is not None:
-        if not isinstance(skills, (str, list)):
-            result.add_error(f"{file_path.name}: skillsは文字列またはリストが必要です")
-        elif isinstance(skills, list):
-            for s in skills:
-                if not isinstance(s, str) or not s:
-                    result.add_error(f"{file_path.name}: skillsの各要素は空でない文字列が必要です")
-                    break
+    validate_string_or_list_field(result, file_path, "skills", frontmatter.get("skills"))
 
     # 本文（システムプロンプト）の確認
     if not body.strip():

--- a/scripts/validators/base.py
+++ b/scripts/validators/base.py
@@ -240,3 +240,105 @@ def get_disabled_warnings(content: str) -> set[str]:
         無効化されている警告IDのset
     """
     return set(DISABLE_PATTERN.findall(content))
+
+
+# ---------------------------------------------------------------------------
+# 共通バリデーションヘルパー
+# ---------------------------------------------------------------------------
+
+
+def to_str(value: Any) -> str:
+    """フロントマター値を安全に文字列化する"""
+    return str(value) if value else ""
+
+
+def add_yaml_warnings(result: ValidationResult, file_path: Path, yaml_warnings: list[str]) -> None:
+    """YAML警告をValidationResultに追加する"""
+    for w in yaml_warnings:
+        result.add_warning(f"{file_path.name}: {w}")
+
+
+def validate_context_field(
+    result: ValidationResult, file_path: Path, frontmatter: dict[str, Any]
+) -> None:
+    """contextフィールドを検証する（forkのみ有効）"""
+    context = frontmatter.get("context")
+    if context is not None:
+        context_str = to_str(context)
+        if context_str and context_str != "fork":
+            result.add_error(
+                f"{file_path.name}: contextの値が不正です: {context_str}（forkのみ有効）"
+            )
+
+
+def validate_agent_field(
+    result: ValidationResult, file_path: Path, frontmatter: dict[str, Any]
+) -> None:
+    """agentフィールドを検証する（空でない文字列が必要）"""
+    agent = frontmatter.get("agent")
+    if agent is not None:
+        if not to_str(agent):
+            result.add_error(f"{file_path.name}: agentは空でない文字列が必要です")
+
+
+def validate_allowed_tools(
+    result: ValidationResult,
+    file_path: Path,
+    frontmatter: dict[str, Any],
+    disabled_warnings: set[str],
+) -> None:
+    """allowed-toolsフィールドを検証する（Bash(*)の広範なワイルドカードを警告）"""
+    allowed_tools = frontmatter.get("allowed-tools")
+    if allowed_tools is not None:
+        tools_str = ""
+        if isinstance(allowed_tools, list):
+            tools_str = ", ".join(str(t) for t in allowed_tools)
+        else:
+            tools_str = str(allowed_tools)
+
+        if "Bash(*)" in tools_str:
+            if WARNING_BROAD_BASH_WILDCARD not in disabled_warnings:
+                result.add_warning(
+                    f"{file_path.name}: allowed-toolsにBash(*)が指定。"
+                    "v2.1.20以降Bash(*)はBashと同等に扱われますが、具体的なパターンを推奨"
+                )
+
+
+def validate_effort_field(
+    result: ValidationResult,
+    file_path: Path,
+    frontmatter: dict[str, Any],
+    valid_values: list[str],
+    *,
+    level: str = "warning",
+    hint: str = "",
+) -> None:
+    """effortフィールドを検証する"""
+    effort = frontmatter.get("effort")
+    if effort is not None:
+        effort_str = to_str(effort)
+        display = hint or "/".join(valid_values)
+        if effort_str and effort_str not in valid_values:
+            if level == "error":
+                result.add_error(
+                    f"{file_path.name}: effortの値が不正です: {effort_str}（{display}）"
+                )
+            else:
+                result.add_warning(f"{file_path.name}: effortが不正: {effort_str}（{display}）")
+
+
+def validate_string_or_list_field(
+    result: ValidationResult, file_path: Path, field_name: str, value: Any
+) -> None:
+    """文字列またはリスト形式のフィールドを検証する"""
+    if value is None:
+        return
+    if not isinstance(value, (str, list)):
+        result.add_error(f"{file_path.name}: {field_name}は文字列またはリストが必要です")
+    elif isinstance(value, list):
+        for item in value:
+            if not isinstance(item, str) or not item:
+                result.add_error(
+                    f"{file_path.name}: {field_name}の各要素は空でない文字列が必要です"
+                )
+                break

--- a/scripts/validators/output_style.py
+++ b/scripts/validators/output_style.py
@@ -4,7 +4,7 @@
 
 from pathlib import Path
 
-from .base import ValidationResult, parse_frontmatter
+from .base import ValidationResult, add_yaml_warnings, parse_frontmatter
 
 
 def validate_output_style(file_path: Path, content: str) -> ValidationResult:
@@ -12,9 +12,7 @@ def validate_output_style(file_path: Path, content: str) -> ValidationResult:
     result = ValidationResult()
     frontmatter, body, yaml_warnings = parse_frontmatter(content)
 
-    # YAML警告を追加
-    for w in yaml_warnings:
-        result.add_warning(f"{file_path.name}: {w}")
+    add_yaml_warnings(result, file_path, yaml_warnings)
 
     # nameフィールドの検証（オプション、指定時はファイル名と一致推奨）
     name = frontmatter.get("name", "")

--- a/scripts/validators/skill.py
+++ b/scripts/validators/skill.py
@@ -6,10 +6,15 @@ import re
 from pathlib import Path
 
 from .base import (
-    WARNING_BROAD_BASH_WILDCARD,
     ValidationResult,
+    add_yaml_warnings,
     get_disabled_warnings,
     parse_frontmatter,
+    to_str,
+    validate_agent_field,
+    validate_allowed_tools,
+    validate_context_field,
+    validate_effort_field,
 )
 
 
@@ -19,13 +24,11 @@ def validate_skill(file_path: Path, content: str) -> ValidationResult:
     frontmatter, body, yaml_warnings = parse_frontmatter(content)
     disabled_warnings = get_disabled_warnings(content)
 
-    # YAML警告を追加
-    for w in yaml_warnings:
-        result.add_warning(f"{file_path.name}: {w}")
+    add_yaml_warnings(result, file_path, yaml_warnings)
 
     # nameの確認
     name = frontmatter.get("name", "")
-    name_str = str(name) if name else ""
+    name_str = to_str(name)
     if not name_str:
         result.add_error(f"{file_path.name}: nameが必須です")
     else:
@@ -42,7 +45,7 @@ def validate_skill(file_path: Path, content: str) -> ValidationResult:
 
     # descriptionの確認
     description = frontmatter.get("description", "")
-    description_str = str(description) if description else ""
+    description_str = to_str(description)
     if not description_str:
         result.add_error(f"{file_path.name}: descriptionが必須です")
     elif len(description_str) > 1024:
@@ -51,17 +54,11 @@ def validate_skill(file_path: Path, content: str) -> ValidationResult:
         )
 
     # contextの確認（forkのみサポート、省略時はメインコンテキスト）
-    context = frontmatter.get("context")
-    if context is not None:
-        context_str = str(context) if context else ""
-        if context_str and context_str != "fork":
-            result.add_error(
-                f"{file_path.name}: contextの値が不正です: {context_str}（forkのみ有効）"
-            )
+    validate_context_field(result, file_path, frontmatter)
 
     # modelの値チェック
     model = frontmatter.get("model", "")
-    model_str = str(model) if model else ""
+    model_str = to_str(model)
     valid_models = ["sonnet", "opus", "haiku", ""]
     if model_str and model_str not in valid_models:
         result.add_warning(f"{file_path.name}: modelが不正: {model_str}（sonnet/opus/haiku）")
@@ -72,37 +69,15 @@ def validate_skill(file_path: Path, content: str) -> ValidationResult:
         result.add_error(f"{file_path.name}: user-invocableはブール値が必要です")
 
     # agentの確認（空でない文字列）
-    agent = frontmatter.get("agent")
-    if agent is not None:
-        agent_str = str(agent) if agent else ""
-        if not agent_str:
-            result.add_error(f"{file_path.name}: agentは空でない文字列が必要です")
+    validate_agent_field(result, file_path, frontmatter)
 
     # allowed-toolsの確認（リスト形式対応）
-    allowed_tools = frontmatter.get("allowed-tools")
-    if allowed_tools is not None:
-        # リスト形式または文字列形式をチェック
-        tools_str = ""
-        if isinstance(allowed_tools, list):
-            tools_str = ", ".join(str(t) for t in allowed_tools)
-        else:
-            tools_str = str(allowed_tools)
-
-        # Bash(*)のような広範なワイルドカードを警告
-        if "Bash(*)" in tools_str:
-            if WARNING_BROAD_BASH_WILDCARD not in disabled_warnings:
-                result.add_warning(
-                    f"{file_path.name}: allowed-toolsにBash(*)が指定。"
-                    "v2.1.20以降Bash(*)はBashと同等に扱われますが、具体的なパターンを推奨"
-                )
+    validate_allowed_tools(result, file_path, frontmatter, disabled_warnings)
 
     # effortの確認（v2.1.80以降）
-    effort = frontmatter.get("effort")
-    if effort is not None:
-        effort_str = str(effort) if effort else ""
-        valid_efforts = ["low", "normal", "high"]
-        if effort_str and effort_str not in valid_efforts:
-            result.add_warning(f"{file_path.name}: effortが不正: {effort_str}（low/normal/high）")
+    validate_effort_field(
+        result, file_path, frontmatter, ["low", "normal", "high"], hint="low/normal/high"
+    )
 
     # hooksの確認（形式警告のみ）
     hooks = frontmatter.get("hooks")

--- a/scripts/validators/slash_command.py
+++ b/scripts/validators/slash_command.py
@@ -5,11 +5,16 @@
 from pathlib import Path
 
 from .base import (
-    WARNING_BROAD_BASH_WILDCARD,
     WARNING_DANGEROUS_OPERATION,
     ValidationResult,
+    add_yaml_warnings,
     get_disabled_warnings,
     parse_frontmatter,
+    to_str,
+    validate_agent_field,
+    validate_allowed_tools,
+    validate_context_field,
+    validate_effort_field,
 )
 
 
@@ -19,9 +24,7 @@ def validate_slash_command(file_path: Path, content: str) -> ValidationResult:
     frontmatter, body, yaml_warnings = parse_frontmatter(content)
     disabled_warnings = get_disabled_warnings(content)
 
-    # YAML警告を追加
-    for w in yaml_warnings:
-        result.add_warning(f"{file_path.name}: {w}")
+    add_yaml_warnings(result, file_path, yaml_warnings)
 
     # descriptionの確認
     if not frontmatter.get("description"):
@@ -40,45 +43,20 @@ def validate_slash_command(file_path: Path, content: str) -> ValidationResult:
             result.add_warning(f"{file_path.name}: argument-hintは空でない文字列が必要です")
 
     # allowed-toolsの確認（リスト形式対応）
-    allowed_tools = frontmatter.get("allowed-tools")
-    if allowed_tools is not None:
-        # リスト形式または文字列形式をチェック
-        tools_str = ""
-        if isinstance(allowed_tools, list):
-            tools_str = ", ".join(str(t) for t in allowed_tools)
-        else:
-            tools_str = str(allowed_tools)
-
-        # Bash(*)のような広範なワイルドカードを警告
-        if "Bash(*)" in tools_str:
-            if WARNING_BROAD_BASH_WILDCARD not in disabled_warnings:
-                result.add_warning(
-                    f"{file_path.name}: allowed-toolsにBash(*)が指定。"
-                    "v2.1.20以降Bash(*)はBashと同等に扱われますが、具体的なパターンを推奨"
-                )
+    validate_allowed_tools(result, file_path, frontmatter, disabled_warnings)
 
     # contextの確認（forkのみサポート、省略時はメインコンテキスト）
-    context = frontmatter.get("context")
-    if context is not None:
-        context_str = str(context) if context else ""
-        if context_str and context_str != "fork":
-            result.add_error(
-                f"{file_path.name}: contextの値が不正です: {context_str}（forkのみ有効）"
-            )
+    validate_context_field(result, file_path, frontmatter)
 
     # agentの確認（空でない文字列）
-    agent = frontmatter.get("agent")
-    if agent is not None:
-        agent_str = str(agent) if agent else ""
-        if not agent_str:
-            result.add_error(f"{file_path.name}: agentは空でない文字列が必要です")
+    validate_agent_field(result, file_path, frontmatter)
 
     # disable-model-invocationの確認
     disable_model = frontmatter.get("disable-model-invocation", False)
     # 危険そうなキーワードが含まれる場合は警告
     dangerous_keywords = ["deploy", "delete", "drop", "production", "本番"]
     description = frontmatter.get("description", "")
-    description_str = str(description) if description else ""
+    description_str = to_str(description)
     if any(kw in body.lower() or kw in description_str.lower() for kw in dangerous_keywords):
         if disable_model is not True:
             if WARNING_DANGEROUS_OPERATION not in disabled_warnings:
@@ -94,11 +72,8 @@ def validate_slash_command(file_path: Path, content: str) -> ValidationResult:
         result.add_warning(f"{file_path.name}: modelが不正: {model_str}（sonnet/opus/haiku）")
 
     # effortの確認（v2.1.80以降）
-    effort = frontmatter.get("effort")
-    if effort is not None:
-        effort_str = str(effort) if effort else ""
-        valid_efforts = ["low", "normal", "high"]
-        if effort_str and effort_str not in valid_efforts:
-            result.add_warning(f"{file_path.name}: effortが不正: {effort_str}（low/normal/high）")
+    validate_effort_field(
+        result, file_path, frontmatter, ["low", "normal", "high"], hint="low/normal/high"
+    )
 
     return result


### PR DESCRIPTION
## Summary
This PR refactors the validation logic across multiple validator modules by extracting common validation patterns into reusable helper functions in the base module. This reduces code duplication and improves maintainability.

## Key Changes

- **New helper functions in `base.py`:**
  - `to_str()`: Safely converts values to strings, treating falsy values as empty strings
  - `add_yaml_warnings()`: Adds YAML warnings to ValidationResult with file path prefix
  - `validate_context_field()`: Validates context field (only "fork" is valid)
  - `validate_agent_field()`: Validates agent field (must be non-empty string)
  - `validate_allowed_tools()`: Validates allowed-tools field with Bash(*) wildcard warning
  - `validate_effort_field()`: Validates effort field against allowed values with configurable error/warning level
  - `validate_string_or_list_field()`: Validates fields that accept string or list format

- **Updated validators to use new helpers:**
  - `agent.py`: Replaced inline validation logic with helper function calls
  - `skill.py`: Replaced inline validation logic with helper function calls
  - `slash_command.py`: Replaced inline validation logic with helper function calls
  - `output_style.py`: Replaced inline YAML warning handling with `add_yaml_warnings()`

- **Comprehensive test coverage:**
  - Added 7 new test classes in `test_base.py` covering all new helper functions
  - Tests verify correct behavior for valid inputs, edge cases, and error conditions

## Implementation Details

- Helper functions follow consistent patterns with `ValidationResult`, `Path`, and `frontmatter` parameters
- `validate_effort_field()` supports both warning and error levels via `level` parameter
- `validate_allowed_tools()` respects disabled warnings configuration
- All helpers properly handle None/empty values and type validation
- Maintains backward compatibility with existing validation behavior

https://claude.ai/code/session_01N57mTm6u5nYrfz5HYABUYw
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
