### PR TITLE
fix: claude-code-actionがpushイベント非対応のためトリガーをpull_requestに戻す

### DIFF
--- a/.github/workflows/plugin-improvement-check.yml
+++ b/.github/workflows/plugin-improvement-check.yml
@@ -37,6 +37,7 @@ jobs:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: 変更されたルール/バリデーターを特定


### PR DESCRIPTION
## 概要
PR #383 でトリガーを `push` に変更したが、`claude-code-action@v1` が `push` イベントをサポートしておらず `Unsupported event type: push` で失敗していた。

## 修正内容
- トリガーを `pull_request: closed` に戻す
- `if: merged == true` ガードを復活
- 差分検出はチェックポイントベース（mainの履歴）を**そのまま維持**

### なぜこれで動くか
元の問題は `git diff BASE_SHA HEAD_SHA` でPRブランチのSHAを参照していたこと。今回の修正ではPRのSHAを一切使わず、`.plugin-check-sha` → HEAD（mainの履歴上のSHA）で差分を取るため、squash mergeでも問題なく動作する。

## 確認事項
- [ ] PRマージ時に `pull_request: closed` でトリガーされること
- [ ] チェックポイントベースの累積差分が正しく検出されること
- [ ] `workflow_dispatch` が従来通り動作すること

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
