### PR TITLE
docs: プラグインモニター (monitors) のドキュメント・バリデーター追加

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -12,6 +12,7 @@
 | [hooks.md](hooks.md) | フック（イベントハンドラ）の定義方法 |
 | [mcp-servers.md](mcp-servers.md) | MCPサーバーの設定方法 |
 | [lsp-servers.md](lsp-servers.md) | LSPサーバーの設定方法 |
+| [monitors.md](monitors.md) | バックグラウンドモニターの定義方法 |
 | [skill-authoring.md](skill-authoring.md) | スキル作成のベストプラクティス |
 | [slash-commands.md](slash-commands.md) | スラッシュコマンドの定義方法 |
 | [plugin-readme.md](plugin-readme.md) | プラグインREADMEの作成ガイドライン |
@@ -37,7 +38,7 @@
 
 | 変数 | 説明 | 使用箇所 |
 |------|------|----------|
-| `${CLAUDE_PLUGIN_ROOT}` | プラグインルートへの絶対パス | hooks, mcp-servers, lsp-servers, allowed-tools |
+| `${CLAUDE_PLUGIN_ROOT}` | プラグインルートへの絶対パス | hooks, mcp-servers, lsp-servers, monitors, allowed-tools |
 | `${CLAUDE_PROJECT_DIR}` | プロジェクトルートへの絶対パス | hooks |
 | `${CLAUDE_SESSION_ID}` | 現在のセッションID | skills, slash-commands |
 | `${CLAUDE_SKILL_DIR}` | スキル自身のディレクトリへの絶対パス（v2.1.64以降） | skills |
@@ -49,7 +50,7 @@
 | `${VAR:-default}` | デフォルト値付き環境変数 | mcp-servers, lsp-servers |
 | `CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS` | Gitクローンのタイムアウト（ミリ秒）。デフォルト120000（120秒）（v2.1.51以降） | marketplace |
 | `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` | `SessionEnd` フックのタイムアウト（ミリ秒）。デフォルトは `hook.timeout` の設定値（v2.1.74以降） | hooks |
-| `${CLAUDE_PLUGIN_DATA}` | プラグインの永続データディレクトリへの絶対パス。アップデートを超えて永続化される（v2.1.78以降） | hooks |
+| `${CLAUDE_PLUGIN_DATA}` | プラグインの永続データディレクトリへの絶対パス。アップデートを超えて永続化される（v2.1.78以降） | hooks, monitors |
 | `CLAUDE_CODE_PLUGIN_SEED_DIR` | プラグインのシードディレクトリ。v2.1.79以降は複数ディレクトリをパス区切り文字（Unix: `:`, Windows: `;`）で区切って指定可能 | marketplace |
 | `CLAUDE_CODE_MCP_SERVER_NAME` | `headersHelper` スクリプト内で利用可能。呼び出し元の MCP サーバー名（v2.1.85以降） | mcp-servers |
 | `CLAUDE_CODE_MCP_SERVER_URL` | `headersHelper` スクリプト内で利用可能。呼び出し元の MCP サーバー URL（v2.1.85以降） | mcp-servers |

--- a/.claude/rules/monitors.md
+++ b/.claude/rules/monitors.md
@@ -1,0 +1,138 @@
+---
+paths: plugins/*/monitors/monitors.json, monitors/monitors.json
+---
+
+# バックグラウンドモニター（monitors/monitors.json）
+
+プラグインモニターは、セッション中に常駐するシェルコマンドを自動起動し、その stdout の各行を Claude への通知として届ける仕組みです。Claude が自発的に watch を張らなくても、プラグイン側で監視対象を宣言できます。
+
+## Monitor tool との関係
+
+プラグインモニターは組み込みの Monitor tool と**同じメカニズム**で動作し、同じ可用性制約を共有します。プラグインモニター固有の差分は、**Claude に指示しなくても自動起動できる**点です。Monitor tool 本体の仕様については公式 [`/en/tools-reference#monitor-tool`](https://code.claude.com/docs/en/tools-reference#monitor-tool) を参照してください。
+
+## 最低バージョン
+
+- プラグインモニター: **Claude Code v2.1.105 以降** が必須
+- Monitor tool 本体: v2.1.98 以降（プラグインモニターを使わない場合はこちらが下限）
+
+## デフォルトファイル位置とフォーマット
+
+| 項目 | 値 |
+|------|----|
+| デフォルトパス | `monitors/monitors.json` |
+| トップレベル型 | JSON 配列（monitor エントリのリスト） |
+
+## plugin.json での指定方法
+
+プラグインルート直下に `monitors/monitors.json` を配置すれば自動検出されます（`plugin.json` での指定は不要）。明示的に指定する場合のパターン:
+
+```json
+{
+  "name": "my-plugin",
+  "monitors": "./config/monitors.json"
+}
+```
+
+`monitors` はインライン配列としても指定できます:
+
+```json
+{
+  "name": "my-plugin",
+  "monitors": [
+    { "name": "deploy-status", "command": "...", "description": "..." }
+  ]
+}
+```
+
+**パス動作ルール**: `monitors` に独自パス文字列を指定した場合、デフォルトの `monitors/monitors.json` は読み込まれません（他のコンポーネント参照と同じ挙動）。
+
+## 必須フィールド
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| `name` | string | プラグイン内でユニークな識別子。プラグイン reload やスキル再起動時の重複プロセスを防ぐために使用される |
+| `command` | string | セッションの作業ディレクトリで永続バックグラウンドプロセスとして実行されるシェルコマンド |
+| `description` | string | 監視対象の短い要約。タスクパネルと通知サマリに表示される |
+
+## オプションフィールド
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| `when` | string | モニター起動タイミング。`"always"`（デフォルト、セッション開始時とプラグイン reload 時に起動）、`"on-skill-invoke:<skill-name>"`（指定したプラグイン内スキルが初めて起動されたときに起動）のいずれか。**これ以外の値は公式ドキュメントで明示されていません** |
+
+## 変数展開
+
+`command` 内では MCP/LSP と同じ変数展開が利用できます:
+
+| 変数 | 用途 |
+|------|------|
+| `${CLAUDE_PLUGIN_ROOT}` | プラグインのインストールディレクトリへの絶対パス（プラグイン更新で変化する） |
+| `${CLAUDE_PLUGIN_DATA}` | 更新をまたいで永続する状態ディレクトリ（`~/.claude/plugins/data/{id}/`） |
+| `${user_config.<key>}` | `userConfig` で宣言した値 |
+| `${ENV_VAR}` | 任意の環境変数 |
+
+プラグインディレクトリで実行したい場合は、コマンド先頭に `cd "${CLAUDE_PLUGIN_ROOT}" &&` を付けて（末尾のスペース忘れに注意）コマンドを連結するパターンが推奨されています。
+
+## ライフサイクル
+
+- `when: "always"`（デフォルト）のモニターは**セッション開始時**および**プラグイン reload 時**に起動
+- `when: "on-skill-invoke:<skill>"` のモニターは該当スキルの初回 dispatch 時に起動
+- コマンドの **stdout の各行が notification として Claude に届く**
+- モニターは**セッション終了時に停止**
+- **セッション中にプラグインを無効化しても、既に実行中のモニタープロセスは停止しません**（再起動防止のため、`name` でユニーク性を担保する必要がある）
+
+## 制約・実行環境
+
+- **インタラクティブ CLI セッション限定**。非対話モードでは起動しません
+- **非サンドボックス実行**。フックと同じ信頼レベルで動作（プラグインをインストール/有効化する行為は、これらのコマンドを信頼することと等価）
+- Monitor tool が利用不可な環境ではスキップされます。具体的には以下のケース:
+  - Amazon Bedrock
+  - Google Vertex AI
+  - Microsoft Foundry
+  - 環境変数 `DISABLE_TELEMETRY` または `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` が設定されている場合
+
+## セキュリティ考慮事項
+
+- モニターは非サンドボックスで実行されるため、コマンド内容はフックと同等の責任で扱うこと
+- `${user_config.<key>}` を参照する場合、sensitive な値はキーチェーンから展開されます。コマンドログに値が漏れないよう注意してください
+- すべてのパスはプラグインルートからの相対表現（`./` 開始）にとどめ、path traversal は使用しないこと
+
+## 実例
+
+公式 plugins-reference に掲載されている例（日本語コメント付き）:
+
+```json
+[
+  {
+    "name": "deploy-status",
+    "command": "${CLAUDE_PLUGIN_ROOT}/scripts/poll-deploy.sh ${user_config.api_endpoint}",
+    "description": "Deployment status changes"
+  },
+  {
+    "name": "error-log",
+    "command": "tail -F ./logs/error.log",
+    "description": "Application error log",
+    "when": "on-skill-invoke:debug"
+  }
+]
+```
+
+- 1つ目: デプロイ状況の変化を監視するスクリプト。セッション開始時に自動起動し、`${user_config.api_endpoint}` がキーチェーン/設定から注入される
+- 2つ目: `debug` スキルが呼ばれた初回のみ `tail -F` でエラーログを監視開始
+
+## 公式ドキュメントで明示されていない項目
+
+以下の点は plugins-reference / tools-reference に明示されておらず、本ドキュメントでも保証しません:
+
+- `stderr` / 終了コードの扱い（通知として届くのは stdout のみと記載）
+- プロセスが異常終了した場合の自動再起動挙動（LSP の `restartOnCrash` に相当する仕組みの有無）
+- 並列起動可能な monitor 数の上限
+- 出力レート制限や通知のバッチング有無
+
+## 出典
+
+- [Plugins reference: Monitors](https://code.claude.com/docs/en/plugins-reference#monitors)
+- [Plugins reference: File locations reference](https://code.claude.com/docs/en/plugins-reference#file-locations-reference)
+- [Plugins reference: Environment variables](https://code.claude.com/docs/en/plugins-reference#environment-variables)
+- [Plugins reference: Path behavior rules](https://code.claude.com/docs/en/plugins-reference#path-behavior-rules)
+- [Tools reference: Monitor tool](https://code.claude.com/docs/en/tools-reference#monitor-tool)

--- a/.claude/rules/monitors.md
+++ b/.claude/rules/monitors.md
@@ -90,6 +90,7 @@ paths: plugins/*/monitors/monitors.json, monitors/monitors.json
   - Google Vertex AI
   - Microsoft Foundry
   - 環境変数 `DISABLE_TELEMETRY` または `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` が設定されている場合
+- `on-skill-invoke:<skill-name>` の `<skill-name>` はプラグイン内のスキル名と一致していること。**バリデーターはスキル名の実在チェック（クロスファイル検証）を行わない**ため、タイプミスがあると該当モニターが起動しない状態となる
 
 ## セキュリティ考慮事項
 

--- a/scripts/tests/test_monitors_json.py
+++ b/scripts/tests/test_monitors_json.py
@@ -202,6 +202,22 @@ class TestValidateMonitorsJson:
         assert not result.has_errors()
         assert any("when" in w for w in result.warnings)
 
+    def test_on_skill_invoke_non_kebab_skill_name(self):
+        """on-skill-invoke のスキル名が kebab-case でない場合は警告（公式未明示のため）"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": "on-skill-invoke:My_Skill",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert any("when" in w for w in result.warnings)
+
     def test_when_empty_string(self):
         """when が空文字列の場合はエラー（必須フィールドと同じ一貫性）"""
         content = json.dumps(

--- a/scripts/tests/test_monitors_json.py
+++ b/scripts/tests/test_monitors_json.py
@@ -1,0 +1,202 @@
+"""
+monitors_json.py のテスト
+"""
+
+import json
+from pathlib import Path
+
+from scripts.validators.monitors_json import validate_monitors_json
+
+
+class TestValidateMonitorsJson:
+    """monitors.json 検証のテスト"""
+
+    def test_valid_minimal(self):
+        """最小限の有効な設定（必須フィールドのみ）"""
+        content = json.dumps(
+            [
+                {
+                    "name": "deploy-status",
+                    "command": "./scripts/poll.sh",
+                    "description": "Deployment status",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert not result.warnings
+
+    def test_valid_full(self):
+        """すべてのフィールドを含む有効な設定"""
+        content = json.dumps(
+            [
+                {
+                    "name": "error-log",
+                    "command": "tail -F ./logs/error.log",
+                    "description": "Application error log",
+                    "when": "always",
+                },
+                {
+                    "name": "debug-monitor",
+                    "command": "${CLAUDE_PLUGIN_ROOT}/scripts/debug.sh",
+                    "description": "Debug monitor",
+                    "when": "on-skill-invoke:debug",
+                },
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert not result.warnings
+
+    def test_valid_on_skill_invoke_kebab_case(self):
+        """on-skill-invoke のスキル名が kebab-case で有効"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": "on-skill-invoke:my-custom-skill",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+
+    def test_invalid_json(self):
+        """不正なJSON"""
+        content = "{ invalid json }"
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("JSON" in e for e in result.errors)
+
+    def test_root_not_array(self):
+        """ルートが配列でない場合はエラー"""
+        content = json.dumps({"name": "foo"})
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("配列" in e for e in result.errors)
+
+    def test_empty_array(self):
+        """空配列は警告のみ"""
+        content = json.dumps([])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert any("空" in w for w in result.warnings)
+
+    def test_entry_not_object(self):
+        """エントリがオブジェクトでない場合はエラー"""
+        content = json.dumps(["not-an-object"])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("オブジェクト" in e for e in result.errors)
+
+    def test_missing_name(self):
+        """name欠落はエラー"""
+        content = json.dumps([{"command": "echo hi", "description": "desc"}])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("name" in e for e in result.errors)
+
+    def test_missing_command(self):
+        """command欠落はエラー"""
+        content = json.dumps([{"name": "mon", "description": "desc"}])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("command" in e for e in result.errors)
+
+    def test_missing_description(self):
+        """description欠落はエラー"""
+        content = json.dumps([{"name": "mon", "command": "echo hi"}])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("description" in e for e in result.errors)
+
+    def test_empty_name(self):
+        """name が空文字列はエラー"""
+        content = json.dumps([{"name": "", "command": "echo hi", "description": "desc"}])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("name" in e for e in result.errors)
+
+    def test_non_string_command(self):
+        """command が文字列でない場合はエラー"""
+        content = json.dumps([{"name": "mon", "command": ["echo", "hi"], "description": "desc"}])
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("command" in e for e in result.errors)
+
+    def test_duplicate_names(self):
+        """name重複はエラー"""
+        content = json.dumps(
+            [
+                {"name": "dup", "command": "echo a", "description": "a"},
+                {"name": "dup", "command": "echo b", "description": "b"},
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("重複" in e for e in result.errors)
+
+    def test_invalid_when(self):
+        """when の値が不正な場合は警告"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": "never",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert any("when" in w for w in result.warnings)
+
+    def test_when_not_string(self):
+        """when が文字列でない場合はエラー"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": True,
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("when" in e for e in result.errors)
+
+    def test_unknown_field_warning(self):
+        """未知のフィールドは警告"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "unknownField": "value",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
+        assert any("unknownField" in w for w in result.warnings)
+
+    def test_on_skill_invoke_without_skill_name(self):
+        """on-skill-invoke: の後にスキル名がない場合は警告"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": "on-skill-invoke:",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert any("when" in w for w in result.warnings)

--- a/scripts/tests/test_monitors_json.py
+++ b/scripts/tests/test_monitors_json.py
@@ -187,7 +187,7 @@ class TestValidateMonitorsJson:
         assert any("unknownField" in w for w in result.warnings)
 
     def test_on_skill_invoke_without_skill_name(self):
-        """on-skill-invoke: の後にスキル名がない場合は警告"""
+        """on-skill-invoke: の後にスキル名がない場合は警告（エラーではない）"""
         content = json.dumps(
             [
                 {
@@ -199,4 +199,21 @@ class TestValidateMonitorsJson:
             ]
         )
         result = validate_monitors_json(Path("monitors.json"), content)
+        assert not result.has_errors()
         assert any("when" in w for w in result.warnings)
+
+    def test_when_empty_string(self):
+        """when が空文字列の場合はエラー（必須フィールドと同じ一貫性）"""
+        content = json.dumps(
+            [
+                {
+                    "name": "mon",
+                    "command": "echo hi",
+                    "description": "desc",
+                    "when": "",
+                }
+            ]
+        )
+        result = validate_monitors_json(Path("monitors.json"), content)
+        assert result.has_errors()
+        assert any("when" in e and "空文字列" in e for e in result.errors)

--- a/scripts/tests/test_plugin_json.py
+++ b/scripts/tests/test_plugin_json.py
@@ -281,3 +281,51 @@ class TestValidatePluginJson:
         result = validate_plugin_json(Path("plugin.json"), content)
         assert result.has_errors()
         assert any("dependencies" in e for e in result.errors)
+
+    # monitors インライン配列のテスト（v2.1.105以降）
+
+    def test_monitors_inline_valid(self):
+        """monitorsがインライン配列で有効な場合エラーなし"""
+        content = json.dumps(
+            {
+                "name": "my-plugin",
+                "monitors": [
+                    {
+                        "name": "deploy",
+                        "command": "./scripts/poll.sh",
+                        "description": "Deploy monitor",
+                    }
+                ],
+            }
+        )
+        result = validate_plugin_json(Path("plugin.json"), content)
+        assert not result.has_errors()
+
+    def test_monitors_inline_missing_required(self):
+        """monitorsインラインで必須フィールド欠落はエラー"""
+        content = json.dumps({"name": "my-plugin", "monitors": [{"name": "only-name"}]})
+        result = validate_plugin_json(Path("plugin.json"), content)
+        assert result.has_errors()
+        assert any("command" in e for e in result.errors)
+
+    def test_monitors_inline_duplicate_names(self):
+        """monitorsインラインでname重複はエラー"""
+        content = json.dumps(
+            {
+                "name": "my-plugin",
+                "monitors": [
+                    {"name": "dup", "command": "a", "description": "a"},
+                    {"name": "dup", "command": "b", "description": "b"},
+                ],
+            }
+        )
+        result = validate_plugin_json(Path("plugin.json"), content)
+        assert result.has_errors()
+        assert any("重複" in e for e in result.errors)
+
+    def test_monitors_string_path_skips_entry_validation(self):
+        """monitorsが文字列パスの場合はエントリ検証をスキップ（ファイル解決は別途）"""
+        content = json.dumps({"name": "my-plugin", "monitors": "./config/monitors.json"})
+        result = validate_plugin_json(Path("plugin.json"), content)
+        # 文字列なのでエントリエラーは出ない（パスフォーマットに関する警告のみ許容）
+        assert not result.has_errors()

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -21,6 +21,7 @@ from validators import (
     validate_lsp_json,
     validate_marketplace_json,
     validate_mcp_json,
+    validate_monitors_json,
     validate_output_style,
     validate_plugin_json,
     validate_readme,
@@ -79,6 +80,11 @@ def validate_file(file_path: Path) -> ValidationResult:
         content = read_file_content(file_path)
         if content is not None:
             result = validate_lsp_json(file_path, content)
+    elif file_path.name == "monitors.json" and "monitors" in path_parts:
+        # バックグラウンドモニター設定
+        content = read_file_content(file_path)
+        if content is not None:
+            result = validate_monitors_json(file_path, content)
     elif file_path.name == "plugin.json" and ".claude-plugin" in path_parts:
         # プラグインマニフェスト
         content = read_file_content(file_path)

--- a/scripts/validators/__init__.py
+++ b/scripts/validators/__init__.py
@@ -8,6 +8,7 @@ from .hooks_json import validate_hooks_json
 from .lsp_json import validate_lsp_json
 from .marketplace_json import validate_marketplace_json
 from .mcp_json import validate_mcp_json
+from .monitors_json import validate_monitors_json
 from .output_style import validate_output_style
 from .plugin_json import validate_plugin_json
 from .readme import validate_readme
@@ -25,6 +26,7 @@ __all__ = [
     "validate_mcp_json",
     "validate_lsp_json",
     "validate_marketplace_json",
+    "validate_monitors_json",
     "validate_output_style",
     "validate_plugin_json",
     "validate_readme",

--- a/scripts/validators/monitors_json.py
+++ b/scripts/validators/monitors_json.py
@@ -1,0 +1,109 @@
+"""
+monitors/monitors.json のバリデーター
+"""
+
+import re
+from pathlib import Path
+
+from .base import ValidationResult, parse_json_safe
+
+# when フィールドの有効値
+VALID_WHEN_ALWAYS = "always"
+# when の on-skill-invoke:<skill-name> パターン
+# 公式はスキル名の書式制約を明示していないが、既存ルール（kebab-case）に合わせて
+# 一致しないものを警告扱いとする
+ON_SKILL_INVOKE_PATTERN = re.compile(r"^on-skill-invoke:[a-z0-9]+(-[a-z0-9]+)*$")
+
+# 既知のフィールド
+KNOWN_FIELDS = {"name", "command", "description", "when"}
+
+# 必須の文字列フィールド
+REQUIRED_STRING_FIELDS = ("name", "command", "description")
+
+
+def _validate_when_value(when: str) -> bool:
+    """when の値が有効な形式かどうかを判定する"""
+    if when == VALID_WHEN_ALWAYS:
+        return True
+    return bool(ON_SKILL_INVOKE_PATTERN.match(when))
+
+
+def validate_monitors_entries(
+    entries: list,
+    file_path: Path,
+    result: ValidationResult,
+    label: str = "monitors",
+) -> None:
+    """
+    モニターエントリ配列を検証する（plugin.json の monitors インライン指定と
+    monitors/monitors.json で共通に使用）
+
+    Args:
+        entries: 検証する配列
+        file_path: エラーメッセージ用のファイルパス
+        result: 検証結果（呼び出し側が初期化する）
+        label: エントリ位置のプレフィックス（デフォルト "monitors"）
+    """
+    seen_names: set[str] = set()
+
+    for i, entry in enumerate(entries):
+        prefix = f"{file_path.name}: {label}[{i}]"
+
+        if not isinstance(entry, dict):
+            result.add_error(f"{prefix}: エントリはオブジェクトが必要です")
+            continue
+
+        # 必須フィールド（string）
+        for field in REQUIRED_STRING_FIELDS:
+            value = entry.get(field)
+            if value is None:
+                result.add_error(f"{prefix}: {field}は必須です")
+            elif not isinstance(value, str):
+                result.add_error(f"{prefix}: {field}は文字列が必要です")
+            elif not value:
+                result.add_error(f"{prefix}: {field}は空文字列にできません")
+
+        # name の重複チェック
+        name = entry.get("name")
+        if isinstance(name, str) and name:
+            if name in seen_names:
+                result.add_error(f"{prefix}: nameが重複しています: {name}")
+            else:
+                seen_names.add(name)
+
+        # when のバリデーション
+        when = entry.get("when")
+        if when is not None:
+            if not isinstance(when, str):
+                result.add_error(f"{prefix}: whenは文字列が必要です")
+            elif not _validate_when_value(when):
+                result.add_warning(
+                    f"{prefix}: whenの値が公式仕様に一致しません: {when}"
+                    '（"always" または "on-skill-invoke:<skill-name>"）'
+                )
+
+        # 未知のフィールド警告
+        for key in entry:
+            if key not in KNOWN_FIELDS:
+                result.add_warning(f"{prefix}: 未知のフィールド: {key}")
+
+
+def validate_monitors_json(file_path: Path, content: str) -> ValidationResult:
+    """バックグラウンドモニター設定（monitors.json）を検証する"""
+    result = ValidationResult()
+
+    data = parse_json_safe(content, file_path, result)
+    if data is None:
+        return result
+
+    # トップレベルは配列
+    if not isinstance(data, list):
+        result.add_error(f"{file_path.name}: ルートは配列が必要です")
+        return result
+
+    if not data:
+        result.add_warning(f"{file_path.name}: monitors設定が空です")
+        return result
+
+    validate_monitors_entries(data, file_path, result)
+    return result

--- a/scripts/validators/monitors_json.py
+++ b/scripts/validators/monitors_json.py
@@ -34,16 +34,7 @@ def validate_monitors_entries(
     result: ValidationResult,
     label: str = "monitors",
 ) -> None:
-    """
-    モニターエントリ配列を検証する（plugin.json の monitors インライン指定と
-    monitors/monitors.json で共通に使用）
-
-    Args:
-        entries: 検証する配列
-        file_path: エラーメッセージ用のファイルパス
-        result: 検証結果（呼び出し側が初期化する）
-        label: エントリ位置のプレフィックス（デフォルト "monitors"）
-    """
+    """モニターエントリ配列を検証する（monitors.json / plugin.json インライン共通）"""
     seen_names: set[str] = set()
 
     for i, entry in enumerate(entries):
@@ -76,6 +67,9 @@ def validate_monitors_entries(
         if when is not None:
             if not isinstance(when, str):
                 result.add_error(f"{prefix}: whenは文字列が必要です")
+            elif not when:
+                # 他の必須フィールドと同じく空文字列はエラー
+                result.add_error(f"{prefix}: whenは空文字列にできません")
             elif not _validate_when_value(when):
                 result.add_warning(
                     f"{prefix}: whenの値が公式仕様に一致しません: {when}"

--- a/scripts/validators/monitors_json.py
+++ b/scripts/validators/monitors_json.py
@@ -63,12 +63,15 @@ def validate_monitors_entries(
                 seen_names.add(name)
 
         # when のバリデーション
+        # 空文字列 "" は明らかに不正な入力のためエラー、それ以外で公式仕様に
+        # 合わない値（例: "on-skill-invoke:" のようにスキル名欠落、大文字スキル名）は
+        # 警告にとどめる。公式はスキル名の書式を明示しておらず、kebab-case 前提が
+        # 緩和される可能性を考慮してエラーにはしない。
         when = entry.get("when")
         if when is not None:
             if not isinstance(when, str):
                 result.add_error(f"{prefix}: whenは文字列が必要です")
             elif not when:
-                # 他の必須フィールドと同じく空文字列はエラー
                 result.add_error(f"{prefix}: whenは空文字列にできません")
             elif not _validate_when_value(when):
                 result.add_warning(

--- a/scripts/validators/plugin_json.py
+++ b/scripts/validators/plugin_json.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 from .base import ValidationResult, parse_json_safe, validate_kebab_case
+from .monitors_json import validate_monitors_entries
 
 
 def validate_plugin_json(file_path: Path, content: str) -> ValidationResult:
@@ -73,6 +74,11 @@ def validate_plugin_json(file_path: Path, content: str) -> ValidationResult:
                     if dep_error:
                         msg = f"dependencies[{i}]はkebab-case（小文字とハイフン）のみ: {dep}"
                         result.add_warning(f"{file_path.name}: {msg}")
+
+    # monitors がインライン配列の場合はエントリを検証（v2.1.105以降）
+    monitors = data.get("monitors")
+    if isinstance(monitors, list):
+        validate_monitors_entries(monitors, file_path, result)
 
     # パスの確認
     path_fields = [


### PR DESCRIPTION
## Summary

v2.1.105 で導入されたプラグイン機能 **Monitors**（バックグラウンドモニター）の rules 整備を行います。

### 追加内容

- **`.claude/rules/monitors.md`** 新規作成
  - 概要（Monitor tool との関係、差分は自動起動可能）
  - 最低バージョン（プラグイン monitors: v2.1.105+、Monitor tool本体: v2.1.98+）
  - `monitors/monitors.json` のデフォルト位置と JSON 配列フォーマット
  - plugin.json での指定方法（インライン配列 / パス文字列）
  - 必須フィールド `name` / `command` / `description`
  - オプション `when` の有効値（`"always"` / `"on-skill-invoke:<skill-name>"`）
  - 変数展開（`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`, `${user_config.*}`, `${ENV_VAR}`）
  - ライフサイクル（セッション開始/reload時起動、stdout各行が通知、セッション終了で停止、プラグイン無効化中も既存プロセスは停止しない）
  - 制約（インタラクティブCLI限定、非サンドボックス=hook同等、Bedrock/Vertex/Foundry/DISABLE_TELEMETRY で無効）
  - 公式未明示項目（stderr/exit code、再起動挙動、並列数、レート制限）

- **`scripts/validators/monitors_json.py`** 新規作成
  - JSON 配列検証、必須フィールド、`name` 重複検出
  - `when` のパターン検証
  - 共通ヘルパー `validate_monitors_entries()` を plugin.json インライン配列でも再利用可能に

- **`scripts/validators/plugin_json.py`** に monitors インライン配列の検証を追加
  - `plugin.json` に `"monitors": [...]` でインライン指定した場合もエントリ検証が走るように

- **テスト**
  - `scripts/tests/test_monitors_json.py` 19テスト（正常系、異常系、エッジケース）
  - `scripts/tests/test_plugin_json.py` に monitors インライン 4テスト追加
  - 合計 372 テスト全通過

- **`__init__.py` / `validate_plugin.py`** にバリデーター配線
- **`.claude/rules/README.md`** 索引と環境変数テーブル（`CLAUDE_PLUGIN_ROOT` / `CLAUDE_PLUGIN_DATA`）に monitors を追加

### 公式ドキュメントとのファクトチェック

公式 [plugins-reference#monitors](https://code.claude.com/docs/en/plugins-reference#monitors) および [tools-reference#monitor-tool](https://code.claude.com/docs/en/tools-reference#monitor-tool) と照合済み。

### 関連PR

- [feat/manifest-factcheck-fix](https://github.com/rfdnxbro/claude-code-marketplace/pull/new/feat/manifest-factcheck-fix)（`plugin-manifest.md` の `monitors` 型修正など）

## Test plan

- [ ] `uvx pytest scripts/tests/ -v` で 372テスト全通過を確認
- [ ] `pre-commit run --all-files` でリント通過を確認
- [ ] `plugin-manifest.md` からの相互リンクが解決することを確認（`feat/manifest-factcheck-fix` とマージ順序を調整）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

