### PR TITLE
fix(workflows): claude-code-review を --body-file 投稿に統一

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,8 +94,18 @@ jobs:
             Optional は最大 3 件。それ以上ある場合、残りは投稿に値しない。
             網羅性ではなくシグナルを優先する。
 
-            ## ステップ 5: `gh pr comment` で 1 回だけ投稿
-            フォーマット（日本語）:
+            ## ステップ 5: コメント本文を一時ファイルに書き出し、`--body-file` で投稿
+            投稿は必ず以下の 2 ステップで行う。**`gh pr comment ... --body "..."` の
+            `--body` インライン形式は禁止**。これはシェル引数の誤組み立てや、Read で
+            取得したファイル内容の混入事故を起こすため:
+
+              1. Write ツールで `/tmp/claude-review-comment.md` にレビュー本文だけを書き出す
+              2. `gh pr comment <PR_NUM> --repo <REPO> --body-file /tmp/claude-review-comment.md`
+                 を 1 回だけ実行する
+
+            `--body-file` で渡すファイルには、以下のフォーマット（日本語）の本文だけを
+            書く。コミットメッセージ、CLAUDE.md、`.claude/rules/*.md`、`gh pr view` の
+            出力、その他レビュー本文以外の文字列を絶対に含めない:
 
               ## レビュー結果
 
@@ -121,4 +131,4 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           allowed_bots: 'devin-ai-integration'
           # yamllint disable-line rule:line-length
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read,Write(/tmp/claude-review-comment.md)"'


### PR DESCRIPTION
## 概要

[PR #453](https://github.com/rfdnxbro/claude-code-marketplace/pull/453) の claude-review run で、レビューコメント本文として **CLAUDE.md の全文** がそのまま投稿される事故が発生したため、再発防止としてプロンプトと allowed-tools を見直す。

事故コメント: [#issuecomment-4336263456](https://github.com/rfdnxbro/claude-code-marketplace/pull/453#issuecomment-4336263456) — 本文が \`/CLAUDE.md\` と完全一致（末尾改行 1 行のみ差）。

## 原因

該当 run の統計:

- \`num_turns: 26\`
- \`permission_denials_count: 18\`（前 run も 14 回発生していた）
- \`duration_ms: 670734\`（約 11 分、タイムアウト 20 分の半分超）

プロンプトが「\`gh pr comment\` で投稿」とだけ指示しており、\`--body\` の引数組み立てが Claude 任せだったため、\`Read\` で読み込んだ CLAUDE.md の文字列バッファが誤って \`--body\` に流入する failure mode に入った。\`Bash\` matcher による拒否が 18 回発生していたことから、Claude は許可されるコマンド形を試行錯誤しており、その過程で \`--body \"<CLAUDE.md 全文>\"\` を組み立ててしまったと推測される。

## 変更内容

\`.github/workflows/claude-code-review.yml\`:

- ステップ 5 を「\`Write\` で \`/tmp/claude-review-comment.md\` にレビュー本文を書き出し、\`--body-file\` で 1 回だけ投稿」の 2 ステップに固定
- \`--body\` インライン形式を明示的に禁止
- レビュー本文以外（CHANGELOG, \`.claude/rules/*.md\`, \`gh pr view\` 出力等）の混入を禁止
- \`allowed-tools\` に \`Write(/tmp/claude-review-comment.md)\` を追加

## 期待効果

- シェル引数の組み立てミスや \`Read\` 結果の \`--body\` 流入を構造的に防止
- \`Bash(gh pr comment:*)\` matcher の prefix マッチで起きていた permission denial の試行錯誤を削減（\`--body-file\` 形式に固定すれば matcher のばらつきが減る）

## テスト計画

- [ ] このPRをマージ後の任意のPRで claude-review が正しい形式で投稿されることを確認
- [ ] permission_denials_count が前回 run（14, 18）から大きく減ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
