### PR TITLE
ci(claude-review): 実行ログを artifact 化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -132,3 +132,16 @@ jobs:
           allowed_bots: 'devin-ai-integration'
           # yamllint disable-line rule:line-length
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read,Write(/tmp/claude-review-comment.md)"'
+
+      # Run Claude Code Review が turn ごとの stream JSON を runner の temp に
+      # 保存している。CI ログには init / result の summary しか出ないため、
+      # サイレント失敗（コメント未投稿で success 終了するケース等）の調査用に
+      # この JSON を artifact としてアップロードする。
+      - name: Upload Claude execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output-pr-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
## 概要

claude-code-action の turn ごとの stream JSON を artifact としてアップロードし、サイレント失敗の調査を可能にする。

## 背景

[PR #454](https://github.com/rfdnxbro/claude-code-marketplace/pull/454) で claude-code-review プロンプトを `--body-file` 投稿に統一して CLAUDE.md ダンプ事故を防いだあと、[PR #457](https://github.com/rfdnxbro/claude-code-marketplace/pull/457) で動作確認したところ：

| 指標 | 修正前（#453の最後のrun） | 修正後（#457） |
|---|---|---|
| `permission_denials_count` | 18 | 9 |
| `num_turns` | 26 | 17 |
| `duration_ms` | 670,734ms | 138,733ms |
| CLAUDE.md ダンプ | あり | **なし** |
| **コメント投稿** | あり（壊れた内容） | **0件** |

CLAUDE.md ダンプは構造的に防げた一方、`subtype: success / is_error: false` で完了しているのに **コメントが 0 件** という新たなサイレント失敗 mode に入った。

ところが CI ログには `init` と `result` の summary しか流れておらず、17 turn の中身がわからないため原因特定が困難だった。

## 変更内容

\`.github/workflows/claude-code-review.yml\` に \`actions/upload-artifact@v4\` ステップを追加:

- 対象: \`\${{ runner.temp }}/claude-execution-output.json\`
- 命名: \`claude-execution-output-pr-<PR番号>\`
- 保持期間: 7日
- \`if: always()\` で失敗時もアップロード

## 期待効果

artifact からは以下が確認可能になる:

- どのタイミングで \`Write\` / \`gh pr comment\` を試みたか
- どのコマンドが permission denial を受けたか
- 最終 message にどんなテキスト応答があったか（コメント未投稿の原因）

## テスト計画

- [ ] このPRをマージ後、別のテストPRを起動
- [ ] artifact が \`claude-execution-output-pr-<N>\` 名で保存されることを確認
- [ ] artifact 内の JSON を解析し、PR #457 のサイレント失敗の原因を特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
