### PR TITLE
fix(workflows): claude-review を stdin heredoc 投稿に変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,18 +94,24 @@ jobs:
             Optional は最大 3 件。それ以上ある場合、残りは投稿に値しない。
             網羅性ではなくシグナルを優先する。
 
-            ## ステップ 5: コメント本文を一時ファイルに書き出し、`--body-file` で投稿
-            投稿は必ず以下の 2 ステップで行う。**`gh pr comment ... --body "..."` の
-            `--body` インライン形式は禁止**。これはシェル引数の誤組み立てや、Read で
-            取得したファイル内容の混入事故を起こすため:
+            ## ステップ 5: `gh pr comment --body-file -` に heredoc でレビュー本文を流して投稿
+            投稿は必ず以下の形式で 1 回だけ実行する。**`gh pr comment ... --body "..."`
+            の `--body` インライン形式は禁止**。シェル引数の誤組み立てや、Read で取得
+            したファイル内容の混入事故を起こすため:
 
-              1. Write ツールで `/tmp/claude-review-comment.md` にレビュー本文だけを書き出す
-              2. `gh pr comment <PR_NUM> --repo <REPO> --body-file /tmp/claude-review-comment.md`
-                 を 1 回だけ実行する
+                gh pr comment <PR_NUM> --repo <REPO> --body-file - << 'REVIEW_EOF'
+                ## レビュー結果
+                ...
+                REVIEW_EOF
 
-            `--body-file` で渡すファイルには、以下のフォーマット（日本語）の本文だけを
-            書く。コミットメッセージ、CLAUDE.md、`.claude/rules/*.md`、`gh pr view` の
-            出力、その他レビュー本文以外の文字列を絶対に含めない:
+            heredoc の delimiter は **必ずシングルクォート付き（`'REVIEW_EOF'`）** に
+            する。これがないと heredoc 内で `$VAR` や `$(...)` が展開され、別ファイル
+            内容や環境変数が混入する事故を招く。
+
+            ファイルへの書き出し（Write ツールや `cat > file` 等）は行わない。heredoc
+            に書く本文には、以下のフォーマット（日本語）の本文だけを書く。コミット
+            メッセージ、CLAUDE.md、`.claude/rules/*.md`、`gh pr view` の出力、その他
+            レビュー本文以外の文字列を絶対に含めない:
 
               ## レビュー結果
 
@@ -131,7 +137,7 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           allowed_bots: 'devin-ai-integration'
           # yamllint disable-line rule:line-length
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read,Write(/tmp/claude-review-comment.md)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read"'
 
       # Run Claude Code Review が turn ごとの stream JSON を runner の temp に
       # 保存している。CI ログには init / result の summary しか出ないため、


### PR DESCRIPTION
## Summary

- PR #457 の artifact 解析で、`Write(/tmp/claude-review-comment.md)` が claude-code-action のサンドボックス作業ディレクトリ境界で拒否されることが判明した。エージェントは複数の代替策（`cat > /tmp/...`、`mkdir + cat`、`python3 -c "..."`、`Write(.claude-pr/...)`）を試みて全て拒否され、最終的に `gh pr comment --body-file -` への stdin heredoc で投稿に成功していた
- ステップ 5 を最初から `--body-file -` の stdin heredoc 経路に固定し、書き込み拒否ループを構造的に解消
- delimiter は `'REVIEW_EOF'` (シングルクォート付き) を必須化し、heredoc 内での `\$VAR` / `\$(...)` 展開による別ファイル混入経路を塞ぐ
- `claude_args` から `Write(/tmp/claude-review-comment.md)` を削除

## CLAUDE.md 流入事故 (PR #453) への回帰リスク

PR #454 のコミットメッセージで述べられている事故の真因は「`--body` の引数組み立てが Claude 任せで、Read で取得した文字列バッファが誤って `--body` に流入する failure mode」。本丸は**投稿本文として何を生成するかのプロンプト指示**であり、ファイル経由か stdin heredoc 経由かは本質ではない。

PR #454 で同時に追加された以下の構造的ガードはそのまま維持:
- `--body` インライン形式の禁止（明文）
- 投稿本文への CLAUDE.md / `.claude/rules/*.md` / `gh pr view` 出力 / コミットメッセージの混入禁止（明文）
- フォーマット指定（## レビュー結果 / Must-fix / Should-fix / Optional / 確認済み観点）

加えて heredoc 経路特有のガードとして delimiter のシングルクォート必須化を新規追加。

PR #460 で導入された artifact upload による監視レイヤも併せ、防御 in depth は維持される想定。

## Test plan

- [ ] このPR自体に対する claude-code-review がエラーなく投稿コメントを生成すること
- [ ] artifact (`claude-execution-output.json`) を確認し、書き込み拒否ループが発生していないこと
- [ ] 投稿コメントに CLAUDE.md / `.claude/rules/*.md` 等の混入がないこと
- [ ] heredoc delimiter が `'REVIEW_EOF'` (シングルクォート付き) で組み立てられていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
