### PR TITLE
chore: doc-check への $schema 追加と plugin-manifest.md 例の更新

### DIFF
--- a/.claude/rules/plugin-manifest.md
+++ b/.claude/rules/plugin-manifest.md
@@ -18,7 +18,7 @@ paths: plugins/*/.claude-plugin/plugin.json, .claude-plugin/plugin.json
 
 | フィールド | 型 | 説明 |
 |-----------|---|------|
-| `$schema` | string | JSONスキーマ参照URL（v2.1.120以降、`claude plugin validate` で受け入れ可能）。公式リファレンスでは `https://json.schemastore.org/claude-code-plugin-manifest.json` の指定が推奨されている。Claude Code 本体はロード時にこのフィールドを無視するため、純粋にエディタの補完・バリデーション用途。 |
+| `$schema` | string | JSONスキーマ参照URL（v2.1.120以降、`claude plugin validate` で受け入れ可能）。公式リファレンス（[plugins-reference](https://code.claude.com/docs/en/plugins-reference)）では `https://json.schemastore.org/claude-code-plugin-manifest.json` の指定が推奨されている。Claude Code 本体はロード時にこのフィールドを無視するため、純粋にエディタの補完・バリデーション用途。 |
 | `version` | string | セマンティックバージョン（例: `2.1.0`） |
 | `description` | string | プラグインの説明 |
 | `author` | object | `{name, email?, url?}` |

--- a/.claude/rules/plugin-manifest.md
+++ b/.claude/rules/plugin-manifest.md
@@ -18,7 +18,7 @@ paths: plugins/*/.claude-plugin/plugin.json, .claude-plugin/plugin.json
 
 | フィールド | 型 | 説明 |
 |-----------|---|------|
-| `$schema` | string | JSONスキーマ参照URL（v2.1.120以降、`claude plugin validate` で受け入れ可能） |
+| `$schema` | string | JSONスキーマ参照URL（v2.1.120以降、`claude plugin validate` で受け入れ可能）。公式リファレンスでは `https://json.schemastore.org/claude-code-plugin-manifest.json` の指定が推奨されている。Claude Code 本体はロード時にこのフィールドを無視するため、純粋にエディタの補完・バリデーション用途。 |
 | `version` | string | セマンティックバージョン（例: `2.1.0`） |
 | `description` | string | プラグインの説明 |
 | `author` | object | `{name, email?, url?}` |
@@ -73,6 +73,7 @@ my-plugin/
 
 ```json
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "my-plugin",
   "version": "1.0.0",
   "description": "プラグインの説明",

--- a/plugins/doc-check/.claude-plugin/plugin.json
+++ b/plugins/doc-check/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "doc-check",
   "version": "0.2.0",
   "description": "変更に関連するドキュメントの整合性を自動チェックするプラグイン",


### PR DESCRIPTION
## Summary

PR #469 / #468 のフォローアップ。残る `doc-check` プラグインへの `$schema` 追加と、リファレンスドキュメント側の整備をまとめて行う。

- [plugins/doc-check/.claude-plugin/plugin.json](plugins/doc-check/.claude-plugin/plugin.json) に `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` を追加
- [.claude/rules/plugin-manifest.md](.claude/rules/plugin-manifest.md) の「メタデータフィールド」表に推奨 URL を明記し、ランタイムが当該フィールドを無視する旨も追記
- 同ファイルの「完全な例」スニペットに `$schema` を含め、新規プラグイン作成時のコピペで自動的に入るようにする

`pr-auto-fix` 側は #468 で対応済みのため、本PRには含めない。これで全プラグイン（claude-code-workflow / pr-auto-fix / doc-check）に `$schema` が揃う。

## Why

PR #469 では自動生成された Issue #467 が `<Claude Code 公式が提供する plugin.json スキーマURL>` というプレースホルダーを残し、それが `https://example.com/plugin-schema.json`（テスト用ダミー値）として実装される事故が起きた。ドキュメント側に公式 URL を明示しておけば、Issue 自動生成時に Claude が直接参照できるため再発を防げる。

公式リファレンス: https://code.claude.com/docs/en/plugins-reference

## Test plan

- [x] `pre-commit run` 相当のチェック（gitleaks / markdownlint / validate-plugin）パス
- [ ] CI 全パスを確認
- [ ] レビュー指摘なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)