### PR TITLE
feat: git-main-sync プラグインを追加（新規セッション開始時に main を最新化）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,6 +45,26 @@
         "monitor"
       ],
       "category": "automation"
+    },
+    {
+      "name": "git-main-sync",
+      "source": "./plugins/git-main-sync",
+      "description": "新規セッション開始時、git管理下なら現在ブランチに応じてmainブランチをpullまたはfetchで最新化する",
+      "version": "0.1.0",
+      "author": {
+        "name": "rfdnxbro"
+      },
+      "homepage": "https://github.com/rfdnxbro/claude-code-marketplace/tree/main/plugins/git-main-sync",
+      "repository": "https://github.com/rfdnxbro/claude-code-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "git",
+        "session-start",
+        "hooks",
+        "workflow",
+        "personal"
+      ],
+      "category": "workflow"
     }
   ]
 }

--- a/plugins/git-main-sync/.claude-plugin/plugin.json
+++ b/plugins/git-main-sync/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "git-main-sync",
+  "version": "0.1.0",
+  "description": "新規セッション開始時、git管理下なら現在ブランチに応じてmainブランチをpullまたはfetchで最新化する",
+  "author": { "name": "rfdnxbro" },
+  "homepage": "https://github.com/rfdnxbro/claude-code-marketplace/tree/main/plugins/git-main-sync",
+  "repository": "https://github.com/rfdnxbro/claude-code-marketplace",
+  "license": "MIT",
+  "keywords": [
+    "git",
+    "session-start",
+    "hooks",
+    "workflow",
+    "personal"
+  ]
+}

--- a/plugins/git-main-sync/README.md
+++ b/plugins/git-main-sync/README.md
@@ -1,0 +1,52 @@
+# git-main-sync
+
+## 概要
+
+新規セッション開始時(`SessionStart` の `startup` / `resume`)に、git 管理下のリポジトリなら `main` ブランチを自動で最新化する hook プラグイン。
+
+現在ブランチに応じて挙動を切り替える:
+
+- 現在ブランチが既定ブランチ(`origin/HEAD`)と一致 → `git pull --ff-only origin <default>`
+- それ以外 → `git fetch origin`(ローカル既定ブランチは触らない)
+
+git 管理下でない / `origin` リモートが無い場合は静かに終了する。pull/fetch に失敗してもセッション開始はブロックしない(`exit 0`)。
+
+## インストール
+
+このマーケットプレイス([rfdnxbro/claude-code-marketplace](https://github.com/rfdnxbro/claude-code-marketplace))を追加した上で:
+
+```bash
+/plugin install git-main-sync@custom-marketplace
+```
+
+## 使い方
+
+インストール後、Claude Code の新規セッション起動・再開のたびに自動で実行される。手動操作は不要。
+
+結果はステータスメッセージとして 1 行通知される:
+
+```text
+[git-main-sync] main を pull で最新化しました
+[git-main-sync] main は既に最新です
+[git-main-sync] origin を fetch しました (現在ブランチ: feat/foo)
+```
+
+### 挙動の詳細
+
+| 状況 | 動作 |
+|------|------|
+| git 管理下でない | 何もしない |
+| `origin` リモートが未設定 | 何もしない |
+| 現在ブランチ = 既定ブランチ | `git pull --ff-only origin <default>` |
+| 現在ブランチ ≠ 既定ブランチ | `git fetch origin` のみ(ローカル既定ブランチは触らない) |
+| pull / fetch がネットワークやコンフリクトで失敗 | 通知して `exit 0` で続行 |
+
+既定ブランチは `git symbolic-ref refs/remotes/origin/HEAD` から検出する。取得できない場合は `main` にフォールバック。
+
+### タイムアウト
+
+hook 全体のタイムアウトは 30 秒。低速なネットワークで遅延する場合は [`hooks/hooks.json`](hooks/hooks.json) の `timeout` を調整する。
+
+## ライセンス
+
+MIT

--- a/plugins/git-main-sync/hooks/hooks.json
+++ b/plugins/git-main-sync/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/sync-main.sh",
+            "timeout": 30,
+            "statusMessage": "main ブランチを最新化中..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/git-main-sync/hooks/sync-main.sh
+++ b/plugins/git-main-sync/hooks/sync-main.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# 新規セッション開始時に、git 管理下のリポジトリで main ブランチを最新化する。
+#   - 現在ブランチが既定ブランチ (origin/HEAD) と一致 → git pull --ff-only
+#   - それ以外                                       → git fetch origin
+# 失敗しても継続する (exit 0)。サイレントに動くため、結果は systemMessage で簡潔に通知。
+
+set -u
+
+cat >/dev/null 2>&1 || true
+
+emit_json() {
+  python3 - "$1" <<'PY'
+import json, sys
+print(json.dumps({"continue": True, "systemMessage": sys.argv[1]}))
+PY
+}
+
+silent_exit() {
+  printf '{"continue":true}\n'
+  exit 0
+}
+
+cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$cwd" 2>/dev/null || silent_exit
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  silent_exit
+fi
+
+if ! git remote get-url origin >/dev/null 2>&1; then
+  silent_exit
+fi
+
+default_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+if [ -z "${default_branch}" ]; then
+  default_branch="main"
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || silent_exit
+
+if [ "${current_branch}" = "${default_branch}" ]; then
+  if output="$(git pull --ff-only origin "${default_branch}" 2>&1)"; then
+    if printf '%s' "${output}" | grep -q "Already up to date"; then
+      emit_json "[git-main-sync] ${default_branch} は既に最新です"
+    else
+      emit_json "[git-main-sync] ${default_branch} を pull で最新化しました"
+    fi
+  else
+    emit_json "[git-main-sync] ${default_branch} の pull に失敗しました (ローカル変更や非fast-forwardの可能性)"
+  fi
+else
+  if git fetch origin >/dev/null 2>&1; then
+    emit_json "[git-main-sync] origin を fetch しました (現在ブランチ: ${current_branch})"
+  else
+    emit_json "[git-main-sync] origin の fetch に失敗しました"
+  fi
+fi
+
+exit 0

--- a/plugins/git-main-sync/hooks/sync-main.sh
+++ b/plugins/git-main-sync/hooks/sync-main.sh
@@ -8,11 +8,12 @@ set -u
 
 cat >/dev/null 2>&1 || true
 
+# JSON 文字列値として安全になるよう " と \ をエスケープして出力する。
 emit_json() {
-  python3 - "$1" <<'PY'
-import json, sys
-print(json.dumps({"continue": True, "systemMessage": sys.argv[1]}))
-PY
+  local msg="$1"
+  msg="${msg//\\/\\\\}"
+  msg="${msg//\"/\\\"}"
+  printf '{"continue":true,"systemMessage":"%s"}\n' "${msg}"
 }
 
 silent_exit() {
@@ -39,8 +40,10 @@ fi
 current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || silent_exit
 
 if [ "${current_branch}" = "${default_branch}" ]; then
-  if output="$(git pull --ff-only origin "${default_branch}" 2>&1)"; then
-    if printf '%s' "${output}" | grep -q "Already up to date"; then
+  before="$(git rev-parse HEAD 2>/dev/null)" || silent_exit
+  if git pull --ff-only origin "${default_branch}" >/dev/null 2>&1; then
+    after="$(git rev-parse HEAD 2>/dev/null)" || after="${before}"
+    if [ "${before}" = "${after}" ]; then
       emit_json "[git-main-sync] ${default_branch} は既に最新です"
     else
       emit_json "[git-main-sync] ${default_branch} を pull で最新化しました"


### PR DESCRIPTION
## Summary

- 新規セッション開始時 (`SessionStart` の `startup|resume`) に、git 管理下なら `main` ブランチを最新化する hook プラグインを追加
- 現在ブランチに応じて挙動を切り替え:
  - 現在ブランチが既定ブランチ (`origin/HEAD`) と一致 → `git pull --ff-only origin <default>`
  - それ以外 → `git fetch origin` (ローカル `main` は触らない)
- git 管理下でない / `origin` が無いリポジトリでは静かに終了 (`exit 0`)、失敗しても処理は継続

## Why

各プロジェクトでセッションを開き直すたびに手動で `main` を pull するのが面倒だったため、起動時に自動で同期するhookをプラグイン化した。feature ブランチで作業中はローカル `main` を勝手に動かしたくないので、その場合は `fetch` のみに留める設計。

## Files

- `plugins/git-main-sync/.claude-plugin/plugin.json` — マニフェスト
- `plugins/git-main-sync/hooks/hooks.json` — `SessionStart` (`startup|resume`) で sync-main.sh を呼ぶ
- `plugins/git-main-sync/hooks/sync-main.sh` — 本体スクリプト (timeout 30秒, スピナーに「main ブランチを最新化中...」を表示)
- `.claude-plugin/marketplace.json` — マーケットプレイスに `git-main-sync` エントリを追加

## Test plan

- [x] `python3 scripts/validate_plugin.py` で警告ゼロ通過
- [x] main ブランチ上で実行 → `[git-main-sync] main は既に最新です` を確認
- [x] feature ブランチ上で実行 → `[git-main-sync] origin を fetch しました (現在ブランチ: ...)` を確認
- [x] pre-commit (gitleaks / validate-plugin) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)