### PR TITLE
docs: SessionStartフックのsourceフィールドとmatcher有効値を追記

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -761,6 +761,17 @@ fi
 
 **注意**: `SessionStart` フックの実行は、起動パフォーマンス改善のため、セッション開始後に約500ms遅延して実行されます。フックが起動直後に即座に実行されることを前提としたロジックがある場合は注意が必要です。
 
+**マッチャー**: 入力JSONの `source` フィールド（セッションの開始方法）に対してマッチします。有効な値:
+
+| matcher値 | 発火タイミング |
+|-----------|--------------|
+| `startup` | 新規セッション開始時 |
+| `resume` | `--resume`、`--continue`、`/resume` によるセッション再開時 |
+| `clear` | `/clear` 実行時 |
+| `compact` | 自動または手動のコンパクション後 |
+
+他のイベントと同様のmatcherパターン指定が可能です（「matcher の仕様」参照）。例えば `"matcher": "startup|resume"` は新規開始・再開時のみ発火し、省略または `"*"` はすべての開始方法にマッチします。
+
 **使用例:**
 
 ```json
@@ -768,6 +779,7 @@ fi
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
@@ -781,7 +793,12 @@ fi
 }
 ```
 
-**`agent_type`入力**: `--agent`フラグでセッションを開始した場合、SessionStartフックのJSON入力に`agent_type`フィールドが含まれます。
+**入力JSON（固有フィールド）:**
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| `source` | string | セッションの開始方法。`"startup"`（新規セッション）/ `"resume"`（再開）/ `"clear"`（`/clear` 後）/ `"compact"`（コンパクション後）。matcherはこの値に対して評価される |
+| `agent_type` | string | `--agent`フラグでセッションを開始した場合のエージェント名 |
 
 **`CLAUDE_ENV_FILE`**: SessionStartフックでは`CLAUDE_ENV_FILE`環境変数にファイルパスが設定されます。このファイルに`export KEY=VALUE`形式で環境変数を書き込むと、セッション全体で利用可能になります。
 


### PR DESCRIPTION
## 概要

`.claude/rules/hooks.md` の SessionStart 節に、入力 JSON の `source` フィールドと matcher の有効値（`startup` / `resume` / `clear` / `compact`）の説明を追記する。

## 背景

Claude Code 公式ドキュメント（<https://code.claude.com/docs/en/hooks>）では、SessionStart フックの入力 JSON に `source` フィールドが存在し、matcher はこの値に対してマッチする（例: `"matcher": "startup|resume"` は起動・再開時のみ発火）。しかし hooks.md にはこの記載がなく、そのギャップが原因で自動 Issue 生成ワークフローが「matcher は未定義値」という誤った改善提案（Issue #568 → PR #571、どちらも close 済み）を生成した。再発防止のため、公式仕様に合わせてドキュメントを補完する。

## 変更内容

- **マッチャー説明の追加**: `source` フィールドに対してマッチすること、有効な4値（`startup` / `resume` / `clear` / `compact`）と各発火タイミングの表、`"startup|resume"` のようなパターン指定が可能であることを記載（PreCompact 節の記述スタイルに準拠）
- **使用例の更新**: `"matcher": "startup|resume"` を含む例に更新
- **入力JSON（固有フィールド）表の追加**: `source` フィールドの説明を追加し、既存の `agent_type` の記述も同表に統合

## 検証

- 公式ドキュメントを WebFetch で確認し、フィールド名・有効値・マッチング挙動を転記
- contribution-guide.md の方針に従い、版数注記は記載していない
- バリデーター（`scripts/validators/hooks_json.py`）は SessionStart を matcher 対応イベントとして登録済みで、matcher 値の中身（正規表現可）は検証対象外のため、バリデーター変更は不要
- `pre-commit run --files .claude/rules/hooks.md` パス（markdownlint 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
