### PR TITLE
fix: claude-review が github-actions bot起因のPRを常に失敗させる問題を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -135,7 +135,7 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          allowed_bots: 'devin-ai-integration'
+          allowed_bots: 'devin-ai-integration,github-actions'
           # yamllint disable-line rule:line-length
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Read"'
 


### PR DESCRIPTION
## Summary

- PR #579 (Issue #578対応) で `claude-review` チェックが `Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.` で失敗する事象を確認
- `anthropics/claude-code-action` のソース（`src/github/validation/actor.ts`）を確認し、`allowed_bots` はカンマ区切りの許可リストであり、bot actorがこのリストに含まれない場合は常にエラーになる仕様であることを確認
- `.github/workflows/claude-code-review.yml` の `allowed_bots` に `devin-ai-integration` のみが設定されており、`auto-implement.yml` が作成する自動生成PR（author: `github-actions[bot]`）が常にこのチェックで失敗していた
- `allowed_bots` に `github-actions` を追加し、自動生成PRも正しくレビューされるようにする

## Test plan

- [x] `pre-commit run yamllint --files .github/workflows/claude-code-review.yml` がPassすることを確認
- [ ] merge後、次回の自動生成PR（`claude-code-update`/`plugin-update`ラベル経由）で `claude-review` が実際に実行・pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)