### PR TITLE
fix: readme.py のコードブロック内リンク誤検知と画像リンク二重報告を修正

### DIFF
--- a/scripts/tests/test_readme.py
+++ b/scripts/tests/test_readme.py
@@ -458,6 +458,189 @@ class TestCodeBlockCheck:
         assert len(result.warnings) == 0
 
 
+class TestCodeBlockLinksExcluded:
+    """コードブロック内リンクの除外に関するテスト"""
+
+    def test_link_in_code_block_not_checked(self, tmp_path):
+        """コードブロック内の実在しないパスへのリンクはリンク切れとして報告されない"""
+        readme_path = tmp_path / "README.md"
+        content = dedent("""
+            # Plugin
+
+            ## 概要
+
+            説明
+
+            ## インストール
+
+            ```markdown
+            [example](./nonexistent-file)
+            ```
+
+            ## 使い方
+
+            使い方
+        """).strip()
+        readme_path.write_text(content)
+
+        result = validate_readme(readme_path, content)
+        assert not result.has_errors()
+
+    def test_link_outside_code_block_still_checked(self, tmp_path):
+        """コードブロック外の実在しないパスへのリンクは引き続きリンク切れとして報告される"""
+        readme_path = tmp_path / "README.md"
+        content = dedent("""
+            # Plugin
+
+            ## 概要
+
+            詳細は[ガイド](docs/nonexistent.md)を参照。
+
+            ```markdown
+            [example](./nonexistent-file)
+            ```
+
+            ## インストール
+
+            手順
+
+            ## 使い方
+
+            使い方
+        """).strip()
+        readme_path.write_text(content)
+
+        result = validate_readme(readme_path, content)
+        link_errors = [e for e in result.errors if "リンク切れ" in e]
+        assert len(link_errors) == 1
+        assert "docs/nonexistent.md" in link_errors[0]
+
+
+class TestImageLinkNotDoubleReported:
+    """画像リンク切れの二重報告解消に関するテスト"""
+
+    def test_broken_image_reported_once(self, tmp_path):
+        """存在しない画像は画像リンク切れのみ報告され、通常のリンク切れとしては報告されない"""
+        readme_path = tmp_path / "README.md"
+        content = dedent("""
+            # Plugin
+
+            ## 概要
+
+            ![alt](nonexistent.png)
+
+            ## インストール
+
+            手順
+
+            ## 使い方
+
+            使い方
+        """).strip()
+        readme_path.write_text(content)
+
+        result = validate_readme(readme_path, content)
+        image_errors = [e for e in result.errors if "画像リンク切れ" in e]
+        normal_link_errors = [
+            e for e in result.errors if "リンク切れ" in e and "画像リンク切れ" not in e
+        ]
+        assert len(image_errors) == 1
+        assert len(normal_link_errors) == 0
+        assert len(result.errors) == 1
+
+    def test_valid_image_no_errors(self, tmp_path):
+        """存在する画像はエラーが出ない"""
+        readme_path = tmp_path / "README.md"
+        image_path = tmp_path / "screenshot.png"
+        image_path.write_bytes(b"fake image data")
+
+        content = dedent("""
+            # Plugin
+
+            ## 概要
+
+            ![alt](screenshot.png)
+
+            ## インストール
+
+            手順
+
+            ## 使い方
+
+            使い方
+        """).strip()
+        readme_path.write_text(content)
+
+        result = validate_readme(readme_path, content)
+        assert not result.has_errors()
+
+    def test_normal_link_still_checked(self, tmp_path):
+        """通常のMarkdownリンク（画像でない）の実在チェックは引き続き正しく動作する"""
+        readme_path = tmp_path / "README.md"
+        target_file = tmp_path / "docs" / "guide.md"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text("# Guide")
+
+        content = dedent("""
+            # Plugin
+
+            ## 概要
+
+            詳細は[ガイド](docs/guide.md)を参照。存在しない[リンク](docs/missing.md)もある。
+
+            ## インストール
+
+            手順
+
+            ## 使い方
+
+            使い方
+        """).strip()
+        readme_path.write_text(content)
+
+        result = validate_readme(readme_path, content)
+        link_errors = [e for e in result.errors if "リンク切れ" in e and "画像リンク切れ" not in e]
+        assert len(link_errors) == 1
+        assert "docs/missing.md" in link_errors[0]
+
+
+class TestStripCodeBlocksHelper:
+    """_strip_code_blocks関数単体のテスト"""
+
+    def test_preserves_line_count(self):
+        """行数が変わらないこと"""
+        from scripts.validators.readme import _strip_code_blocks
+
+        content = dedent("""
+            line1
+            ```python
+            code line
+            ```
+            line2
+        """).strip()
+        stripped = _strip_code_blocks(content)
+        assert len(stripped.split("\n")) == len(content.split("\n"))
+
+    def test_removes_code_block_content(self):
+        """コードブロック内の行が空になること"""
+        from scripts.validators.readme import _strip_code_blocks
+
+        content = dedent("""
+            before
+            ```
+            [example](./nonexistent-file)
+            ```
+            after
+        """).strip()
+        stripped = _strip_code_blocks(content)
+        lines = stripped.split("\n")
+        assert lines[0] == "before"
+        assert lines[1] == ""
+        assert lines[2] == ""
+        assert lines[3] == ""
+        assert lines[4] == "after"
+
+
 class TestLinkWithEmptyPath:
     """アンカーのみリンクのテスト"""
 

--- a/scripts/tests/test_readme.py
+++ b/scripts/tests/test_readme.py
@@ -5,7 +5,7 @@ readme.py のテスト
 from pathlib import Path
 from textwrap import dedent
 
-from scripts.validators.readme import validate_readme
+from scripts.validators.readme import _strip_code_blocks, validate_readme
 
 
 class TestValidateReadme:
@@ -609,8 +609,6 @@ class TestStripCodeBlocksHelper:
 
     def test_preserves_line_count(self):
         """行数が変わらないこと"""
-        from scripts.validators.readme import _strip_code_blocks
-
         content = dedent("""
             line1
             ```python
@@ -623,8 +621,6 @@ class TestStripCodeBlocksHelper:
 
     def test_removes_code_block_content(self):
         """コードブロック内の行が空になること"""
-        from scripts.validators.readme import _strip_code_blocks
-
         content = dedent("""
             before
             ```

--- a/scripts/validators/readme.py
+++ b/scripts/validators/readme.py
@@ -24,8 +24,8 @@ def validate_readme(file_path: Path, content: str) -> ValidationResult:
         if not re.search(pattern, content, re.IGNORECASE):
             result.add_error(f"{file_path.name}: 必須セクション「{section_name}」がありません")
 
-    # 相対パスリンクのチェック
-    _check_relative_links(file_path, content, result)
+    # 相対パスリンクのチェック（コードブロック内のサンプルリンクは対象外にする）
+    _check_relative_links(file_path, _strip_code_blocks(content), result)
 
     # コードブロックの言語指定チェック
     _check_code_blocks(file_path, content, result)
@@ -33,11 +33,37 @@ def validate_readme(file_path: Path, content: str) -> ValidationResult:
     return result
 
 
+def _strip_code_blocks(content: str) -> str:
+    """フェンス付きコードブロックの中身を空行に置き換えた文字列を返す
+
+    行数・全体の構造は変えず、コードブロック内（フェンス行自体も含む）の
+    内容だけを消す。判定ロジックは_check_code_blocksと同様。
+    """
+    lines = content.split("\n")
+    in_code_block = False
+    stripped_lines = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            # コードブロックの開始/終了フラグを反転
+            in_code_block = not in_code_block
+            stripped_lines.append("")
+        elif in_code_block:
+            stripped_lines.append("")
+        else:
+            stripped_lines.append(line)
+
+    return "\n".join(stripped_lines)
+
+
 def _check_relative_links(file_path: Path, content: str, result: ValidationResult) -> None:
     """相対パスのリンク切れをチェックする"""
     # Markdownリンク: [text](path) 形式
     # 外部URL（http://, https://）は除外
-    link_pattern = r"\[([^\]]*)\]\(([^)]*)\)"
+    # 画像記法 ![alt](path) の [alt](path) 部分は除外（直前の!を否定先読み）
+    link_pattern = r"(?<!!)\[([^\]]*)\]\(([^)]*)\)"
     base_dir = file_path.parent
 
     for match in re.finditer(link_pattern, content):


### PR DESCRIPTION
## 概要

アーキテクチャレビューで見つかった `scripts/validators/readme.py` の相対リンクチェック機能に関する2つの誤検知バグを修正します。

## 変更内容

### 1. フェンス付きコードブロック内のサンプルリンクを誤検知しないようにする

`_check_relative_links` は、README.mdの全文（コードブロックの中身も含む）を正規表現でスキャンしてMarkdownリンクの実在チェックを行っていました。そのため、README内でサンプルコードとして `[example](./path/to/something)` のような架空のリンクを示していても、実在しないファイルとしてリンク切れエラーを誤って報告していました。

- `_strip_code_blocks(content: str) -> str` を新設し、フェンス付きコードブロック（3連続バッククォートで開始・終了する範囲）の中身をフェンス行も含めて空行に置き換えた文字列を返すようにしました。行数・全体構造は変えず、コードブロックの中身のみを消します。
- `validate_readme` 内で `_check_relative_links` に渡すcontentを `_strip_code_blocks(content)` に変更しました。
- `_check_code_blocks`（コードブロックの言語指定チェック）はコードブロック自体の検出が必要なため、引き続き元の `content` をそのまま渡しています。

### 2. 画像リンクの二重報告を解消する

`link_pattern`（通常のMarkdownリンク検出用の正規表現）が、`![alt](path)` という画像記法の `[alt](path)` 部分にも意図せずマッチしていました。そのため、存在しない画像を参照している場合、`_check_relative_links` 内で「リンク切れ」として報告され、続く画像専用チェック（`image_pattern`）でも「画像リンク切れ」として報告され、同じ問題が2回報告されていました。

- `link_pattern` の先頭に否定先読み `(?<!!)` を追加し、開き角括弧の直前が `!` でない場合のみマッチするように修正しました（`r"\[([^\]]*)\]\(([^)]*)\)"` → `r"(?<!!)\[([^\]]*)\]\(([^)]*)\)"`）。

## 確認事項

- `scripts/tests/test_readme.py` にテストを追加しました。
  - コードブロック内の実在しないパスへのリンクがリンク切れとして報告されないこと
  - コードブロック外の実在しないパスへのリンクは引き続き正しくリンク切れとして報告されること（回帰確認）
  - 実在しない画像を参照した場合、「画像リンク切れ」のみ報告され「リンク切れ」との二重報告にならないこと
  - 実在する画像を参照した場合はエラーが出ないこと
  - 通常のMarkdownリンク（画像でない）の実在チェックが引き続き正しく動作すること
  - `_strip_code_blocks` 単体の行数保持・中身除去の挙動
- `uvx ruff check scripts/` / `uvx ruff format scripts/` 相当のチェック（サンドボックス制約により `python3 -m ruff check --no-cache` / `python3 -m ruff format --no-cache --diff` で代替実行）を通過しました。
- `pytest scripts/tests/ -v --cov=validators --cov-report=term --cov-fail-under=100` を実行し、全528件のテストが通過、カバレッジ100%を維持していることを確認しました。
- 指示された対象ファイル（`scripts/validators/readme.py`, `scripts/tests/test_readme.py`）以外は変更していません。

## 補足（作業環境に関する注記）

サンドボックス環境の制約により、`uvx` 経由でのツール実行（ruff/pytest）がネットワーク・キャッシュディレクトリの権限問題で失敗したため、システムにインストール済みのruff、および一時ディレクトリにインストールしたpytest/pytest-covを用いて代替実行しました。実行結果・カバレッジは上記の通り問題ありません。

🤖 Generated with automated architecture review follow-up
