### PR TITLE
fix: auto-implement.yml のBash(*)権限を最小権限化しpre-commitキャッシュを追加

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -57,6 +57,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: pre-commitキャッシュを復元
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: pre-commitをセットアップ
         run: |
           pip install pre-commit
@@ -166,8 +172,9 @@ jobs:
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
           # ラベルは手動付与のため、Edit/Writeのパス制限は不要
-          # Bashは全コマンド許可（ラベルは手動付与なので信頼できる）
-          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(*)"'
+          # ただし外部由来のCHANGELOGを起点にIssueが自動生成されbotラベルが付与される経路もあるため、
+          # Bashはplugin-updateステップと同様に実行手順で必要なコマンドのみに絞る
+          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *),Bash(pre-commit run*)"'
 
       - name: Claudeで実装を実行（plugin-update）
         if: github.event.label.name == 'plugin-update'

--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
 
       - name: pre-commitをセットアップ
         run: |
@@ -171,9 +173,9 @@ jobs:
             - リポジトリに永続的に必要なファイルのみ作成・変更すること
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
-          # ラベルは手動付与のため、Edit/Writeのパス制限は不要
-          # ただし外部由来のCHANGELOGを起点にIssueが自動生成されbotラベルが付与される経路もあるため、
-          # Bashはplugin-updateステップと同様に実行手順で必要なコマンドのみに絞る
+          # 外部由来のCHANGELOGを起点にIssueが自動生成されbotラベルが付与される
+          # 経路があるため、Bashはplugin-updateステップと同様に実行手順で
+          # 必要なコマンドのみに絞る（Edit/Writeのパス制限要否は別途検討）
           claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *),Bash(pre-commit run*)"'
 
       - name: Claudeで実装を実行（plugin-update）


### PR DESCRIPTION
## 概要

アーキテクチャレビューで指摘された、`.github/workflows/auto-implement.yml` における権限設定の非対称性を解消します。

`claude-code-update` ラベル向けステップ（「Claudeで実装を実行（claude-code-update）」）は `Bash(*)` で任意のシェルコマンドを許可していましたが、同じワークフロー内の `plugin-update` ステップは最小権限化された許可リストになっており非対称でした。`claude-code-update` ステップの実行手順を確認したところ、実際に必要なコマンドは `pre-commit run --all-files` と、必要に応じた `uvx` / `python3 scripts/*` / `npx` のみであり、任意コマンド実行は不要と判断しました。

あわせて、`pre-commit` セットアップ前にフック環境のキャッシュを追加し、ワークフロー実行速度を改善します。

## 変更内容

### 1. `claude-code-update` ステップのBash最小権限化

- `claude_args` の `--allowed-tools` を `Bash(*)` から `plugin-update` ステップと同一の許可リストに変更しました。
  - 変更前: `Read,Grep,Glob,Edit,Write,Bash(*)`
  - 変更後: `Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *),Bash(pre-commit run*)`
- 直前にあった「Bashは全コマンド許可（ラベルは手動付与なので信頼できる）」というコメントは実態と合わなくなるため、外部由来のCHANGELOGを起点にIssueが自動生成されbotラベルが付与されうる経路がある旨を明記したコメントに置き換えました。

### 2. pre-commitのフック環境キャッシュを追加

- 「pre-commitをセットアップ」ステップの直前に `actions/cache@v4` を用いたキャッシュステップ（「pre-commitキャッシュを復元」）を追加しました。
- キャッシュ対象は `~/.cache/pre-commit`、キーは `.pre-commit-config.yaml` のハッシュに基づきます。
- キャッシュミス時も既存の `pip install pre-commit && pre-commit install` がそのまま動作するため、挙動は変わらず速度改善のみです。

## 確認事項

- [x] `pre-commit run --files .github/workflows/auto-implement.yml`（yamllint / gitleaks / markdownlint 等の関連フック）がすべてPassすることを確認
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` 相当の方法（pre-commitのyamllintフック用venvを利用）でYAML構文が壊れていないことを確認
- [x] 変更対象は `.github/workflows/auto-implement.yml` のみで、`plugin-update` ステップやその他の箇所は変更していないこと
- [ ] 実際に `claude-code-update` ラベル付きIssueで自動実装ワークフローを走らせ、絞ったBash許可リストで実行手順（pre-commit実行含む）が問題なく完了すること（レビュー後の実運用確認）

---
🤖 Generated with automated architecture review follow-up
