### PR TITLE
fix: PRレビュー・@claude起動の重複実行を防ぐconcurrency制御を追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## 概要

アーキテクチャレビューで指摘された、Claude Code Action系ワークフローの重複起動問題を修正します。

`claude-code-review.yml` と `claude.yml` はいずれも concurrency 制御がなく、PRへの連続push（synchronizeイベント）や `@claude` への連投コメントで、同一PR/Issueに対して複数のClaude Code Actionが並列起動し、無駄なAPI課金を発生させていました。

## 変更内容

### `.github/workflows/claude-code-review.yml`

`on:` ブロックの直後に以下を追加しました。

```yaml
concurrency:
  group: claude-review-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

このワークフローは `pull_request` の `opened` / `synchronize` のみで起動するため、`github.event.pull_request.number` は常に取得できます。同一PRへの新しいpushが来たら、古いdiffに対する実行中のレビューは意味を失うため `cancel-in-progress: true` としています。

### `.github/workflows/claude.yml`

`on:` ブロックの直後に以下を追加しました。

```yaml
concurrency:
  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
  cancel-in-progress: false
```

このワークフローは `issue_comment` / `pull_request_review_comment` / `issues` / `pull_request_review` の4種類のイベントで起動します。`issue_comment` と `issues` は `github.event.issue.number` を、`pull_request_review_comment` と `pull_request_review` は `github.event.pull_request.number` を持つため、`||` で両方をカバーしています。`@claude` に連投した際に進行中のタスクを打ち切ってしまうと作業が失われる可能性があるため、`cancel-in-progress: false` としてキューイングによる直列化を選択しています。

既存の `auto-implement.yml` / `changelog-monitor.yml` / `plugin-improvement-check.yml` も同様の `concurrency` パターンを採用しており、本PRの変更はそのスタイルに合わせています。

## 確認事項

- 対象2ファイル以外への変更はありません（`git diff` で確認済み）。
- `paths` フィルタの有効化など、スコープ外の変更は行っていません。
- YAML構文チェック: 本セッションのサンドボックス環境では `uvx`（yamllint / ruff 等）がmacOSの `system-configuration` クレート由来のパニックで起動不能、`pip install` もプロキシ越しのSSL証明書検証エラーで失敗したため、`uvx yamllint` を実行できませんでした。代替として以下を実施し、問題がないことを確認しています。
  - Ruby標準ライブラリ（Psych）で両ファイルの `YAML.load_file` が例外なく成功することを確認（構文検証）。
  - `.yamllint.yml` のルール（2スペースインデント、行長160文字以内、末尾空白なし、タブ不使用）に対して、追加した `concurrency` ブロックを手動で照合し、違反がないことを確認。
  - `pre-commit run yamllint` も同様の理由（GitHubへのProxy CONNECTが中断される）で実行できませんでした。
- Pythonファイル（`scripts/` 配下）・Markdownファイルは変更していないため、該当するlint/testステップは対象外です。

🤖 Generated with automated architecture review follow-up
