### PR TITLE
fix: agents/配下のドキュメント用.mdへの誤エラーを修正（agents.md仕様準拠）

### DIFF
--- a/scripts/tests/test_agent.py
+++ b/scripts/tests/test_agent.py
@@ -25,6 +25,8 @@ class TestValidateAgent:
         assert len(result.warnings) == 0
 
     def test_missing_name(self):
+        """nameフィールドがないfrontmatterはエージェント定義として扱われず、
+        エラー・警告を一切出さないことを確認（agents.md仕様: ドキュメント用.md扱い）"""
         content = dedent("""
             ---
             description: 説明
@@ -32,8 +34,36 @@ class TestValidateAgent:
             本文
         """).strip()
         result = validate_agent(Path("agent.md"), content)
-        assert result.has_errors()
-        assert any("name" in e for e in result.errors)
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
+
+    def test_no_frontmatter_at_all(self):
+        """frontmatter自体がない素のMarkdown（README.md等）は
+        エラー・警告を一切出さないことを確認（agents.md仕様: ドキュメント用.md扱い）"""
+        content = dedent("""
+            # エージェント一覧
+
+            このディレクトリにはエージェント定義が含まれます。
+        """).strip()
+        result = validate_agent(Path("README.md"), content)
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
+
+    def test_missing_name_with_invalid_other_fields(self):
+        """nameがなければ、他のフィールド（description等）が不正な値でも
+        一切エラー・警告が出ないことを確認（agents.md仕様: ドキュメント用.md扱い）"""
+        content = dedent("""
+            ---
+            description:
+            model: invalid-model
+            permissionMode: invalid
+            memory: global
+            ---
+            本文
+        """).strip()
+        result = validate_agent(Path("agent.md"), content)
+        assert not result.has_errors()
+        assert len(result.warnings) == 0
 
     def test_invalid_name_format(self):
         content = dedent("""

--- a/scripts/validators/agent.py
+++ b/scripts/validators/agent.py
@@ -38,18 +38,20 @@ def validate_agent(file_path: Path, content: str) -> ValidationResult:
     result = ValidationResult()
     frontmatter, body, yaml_warnings = parse_frontmatter(content)
 
-    add_yaml_warnings(result, file_path, yaml_warnings)
-
-    # 必須フィールドの確認
+    # nameフィールドを持たない.mdはエージェント定義として扱わない
+    # （agents/配下のREADME.md等のドキュメント用ファイルには警告を一切出さない。
+    # .claude/rules/agents.md参照）
     name = frontmatter.get("name", "")
     name_str = to_str(name)
     if not name_str:
-        result.add_error(f"{file_path.name}: nameが必須です")
-    else:
-        # kebab-case（小文字とハイフンのみ）チェック
-        kebab_error = validate_kebab_case(name_str)
-        if kebab_error:
-            result.add_error(f"{file_path.name}: {kebab_error}")
+        return result
+
+    add_yaml_warnings(result, file_path, yaml_warnings)
+
+    # kebab-case（小文字とハイフンのみ）チェック
+    kebab_error = validate_kebab_case(name_str)
+    if kebab_error:
+        result.add_error(f"{file_path.name}: {kebab_error}")
 
     # descriptionの確認
     description = frontmatter.get("description", "")


### PR DESCRIPTION
## 概要

`.claude/rules/agents.md` では「frontmatterに`name`フィールドを持つ.mdファイルのみがエージェント定義として扱われる。`name`を持たないドキュメント用.md（例: `agents/`配下のREADME.mdなど）には警告を一切出さない」という仕様が明記されています。

しかし `scripts/validate_plugin.py` のディスパッチはパスに`agents`が含まれ拡張子が`.md`であることのみを条件に `validate_agent` を呼び出しており、`scripts/validators/agent.py` の `validate_agent` は `name` フィールドが空の場合に無条件で「nameが必須です」エラーを追加していました。結果として、`agents/`配下に置かれた素のドキュメント用.md（frontmatterがない、または`name`フィールドを持たないもの）が、実際にはエージェント定義でないにもかかわらず誤ってエラー扱いされていました。

## 変更内容

- `scripts/validators/agent.py`
  - `validate_agent` 関数で `parse_frontmatter` 直後に `name` フィールドの有無を確認し、空文字列の場合は即座に空の `ValidationResult`（エラー・警告なし）を返すよう変更。
  - `name` が存在する場合のみ、`add_yaml_warnings` の呼び出しを含む従来の全チェック（kebab-case、description必須、model/permissionMode/memory等の各種チェック）を実行するように変更。
- `scripts/tests/test_agent.py`
  - `test_missing_name` を新仕様（`name`なし＝ドキュメント扱いでエラー・警告なし）に合わせて更新。
  - `test_no_frontmatter_at_all` を追加: frontmatter自体がない素のMarkdown（README.md等を模したケース）でエラー・警告が出ないことを確認。
  - `test_missing_name_with_invalid_other_fields` を追加: `name`が無ければ`description`/`model`/`permissionMode`/`memory`が不正な値でも一切エラー・警告が出ないことを確認。

## 確認事項

- `uvx ruff check scripts/` / `uvx ruff format scripts/` 相当のチェックを通過（サンドボックス制約により `python3 -m ruff` を代替使用、結果は同一）。
- `pytest scripts/tests/ -v --cov=validators --cov-report=term --cov-fail-under=100` を実行し、全523件のテストが通過、`validators/`配下のカバレッジ100%を維持していることを確認（`agent.py`も100%）。
- 既存の`name`フィールドを持つテストケース（`test_valid_agent`, `test_invalid_name_format`等）はすべて `name: test-agent` 等が設定済みのため、今回の変更による影響がないことを確認済み。
