### PR TITLE
docs: README公開プラグイン表にgit-main-syncを追加しpr-auto-fixのdescription表記を統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Claude Codeの機能を拡張するプラグイン（スラッシュコマンド
 |-----------|------|------|
 | [claude-code-workflow](plugins/claude-code-workflow/) | Claude Codeの個人的な作業スタイル（エージェント編成、文体ガイド等）をスキルとして集約 | 🔧 開発中 |
 | [pr-auto-fix](plugins/pr-auto-fix/) | PR 作成後に CI 失敗・レビュー・コンフリクトを自動検知し、自明な修正は commit & push、判断要は PR コメントでエスカレーション | 🔧 開発中 |
+| [git-main-sync](plugins/git-main-sync/) | 新規セッション開始時、git管理下なら現在ブランチに応じてmainブランチをpullまたはfetchで最新化する | 🔧 開発中 |
 
 ## ディレクトリ構成
 

--- a/plugins/pr-auto-fix/.claude-plugin/plugin.json
+++ b/plugins/pr-auto-fix/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr-auto-fix",
   "version": "0.2.0",
-  "description": "PR 作成後に CI 失敗・レビュー・コンフリクトを自動検知し、自明な修正は commit & push、判断要は GitHub PR にコメントしてエスカレーションするプラグイン",
+  "description": "PR 作成後に CI 失敗・レビュー・コンフリクトを自動検知し、自明な修正は commit & push、判断要は PR コメントでエスカレーションするプラグイン",
   "author": {
     "name": "rfdnxbro"
   },


### PR DESCRIPTION
## 概要

アーキテクチャレビューで見つかった、README.mdとプラグイン定義ファイル間の表記不整合を2件修正します。

## 変更内容

1. **README.mdの「公開プラグイン」表にgit-main-syncの行を追加**
   `.claude-plugin/marketplace.json` には `git-main-sync` が登録済みで `plugins/git-main-sync/` も実在するが、README.mdの公開プラグイン表には反映されていなかったため、既存の2行と同じフォーマットで行を追加しました。
   - 説明文は `plugins/git-main-sync/.claude-plugin/plugin.json` のdescriptionをそのまま使用
   - 状態列は `🔧 開発中` とした（コミット数が他2プラグインより少なく（3件）、`plugins/git-main-sync/README.md` の内容からも実験的なhookプラグインの域を出ておらず、他2行と同水準の成熟度と判断）

2. **`plugins/pr-auto-fix/.claude-plugin/plugin.json` のdescriptionを統一**
   pr-auto-fixのdescriptionが以下のように3箇所で微妙に異なっていました。
   - `plugin.json`: 「...判断要は **GitHub PR にコメントして** エスカレーションするプラグイン」
   - `marketplace.json`: 「...判断要は **PR コメントで** エスカレーションするプラグイン」
   - `README.md`: 「...判断要は **PR コメントで** エスカレーション」

   `marketplace.json` と `README.md` の表現が一致していたため、`plugin.json` 側をそちらに合わせて修正しました。

## 対象外（今回のスコープ外）

- インストールコマンドの記法統一（`claude plugin install` / `/plugin install` / `--marketplace` オプション等の混在）: どの記法を正とするか判断が分かれるスタイルの問題のため見送り
- `git-main-sync` の `license` フィールド: 既に `MIT` が設定済みのため変更不要

## 確認事項

- [x] `python3 -c "import json; json.load(open('plugins/pr-auto-fix/.claude-plugin/plugin.json'))"` でJSON構文が壊れていないことを確認
- [x] `python3 scripts/validate_plugin.py plugins/pr-auto-fix/.claude-plugin/plugin.json` でバリデーションエラーが出ないことを確認
- [x] `pre-commit run markdownlint --files README.md` でmarkdownlintを実行し問題ないことを確認
- [x] `pre-commit run validate-plugin --files plugins/pr-auto-fix/.claude-plugin/plugin.json` でプラグイン検証が通ることを確認
- Pythonコード・YAMLファイルの変更は含まれないため、pytest/yamllintは対象外

🤖 Generated with automated architecture review follow-up
