### PR TITLE
fix: base.py のYAMLフロントマターパーサーが行末コメントを値に混入させる不具合を修正

### DIFF
--- a/scripts/tests/test_base.py
+++ b/scripts/tests/test_base.py
@@ -191,6 +191,70 @@ class TestParseFrontmatter:
         assert fm["name"] == "test"
         assert "#" not in fm
 
+    def test_inline_comment_after_value(self):
+        """値の末尾のインラインコメントが除去されることを確認"""
+        content = dedent("""
+            ---
+            model: sonnet # 説明のコメント
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["model"] == "sonnet"
+
+    def test_quoted_value_with_hash_inside(self):
+        """クォート内のシャープ記号はコメントとして除去されないことを確認"""
+        content = dedent("""
+            ---
+            description: "Use # to comment in bash"
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["description"] == "Use # to comment in bash"
+
+    def test_quoted_value_followed_by_inline_comment(self):
+        """クォートされた値の後に続く本当のインラインコメントが除去されることを確認"""
+        content = dedent("""
+            ---
+            description: "実際の値" # これはコメント
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["description"] == "実際の値"
+
+    def test_value_is_comment_only_becomes_list_key(self):
+        """値がシャープ記号のみで始まる場合は空値としてリストキー扱いになることを確認"""
+        content = dedent("""
+            ---
+            key: # comment only
+            name: test
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["key"] == ""
+        assert fm["name"] == "test"
+
+    def test_list_item_inline_comment_stripped(self):
+        """リスト項目のインラインコメントが除去されることを確認"""
+        content = dedent("""
+            ---
+            tools:
+              - item1 # コメント
+              - item2
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["tools"] == ["item1", "item2"]
+
+    def test_unclosed_quote_value_kept_as_is(self):
+        """閉じクォートが見つからない場合は値全体をそのまま保持することを確認"""
+        content = dedent("""
+            ---
+            description: "unterminated
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["description"] == '"unterminated'
+
     def test_nested_object_warning(self):
         """ネストされたオブジェクトで警告が出ることを確認"""
         content = dedent("""

--- a/scripts/tests/test_base.py
+++ b/scripts/tests/test_base.py
@@ -221,6 +221,39 @@ class TestParseFrontmatter:
         fm, body, warnings = parse_frontmatter(content)
         assert fm["description"] == "実際の値"
 
+    def test_quoted_value_hash_without_space_not_comment(self):
+        """閉じクォート直後にスペースなしで#が続く場合、非クォート値の規約
+        （半角スペース+#が必須）と統一してコメント扱いしないことを確認"""
+        content = dedent("""
+            ---
+            description: "text"#anchor
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["description"] == '"text"#anchor'
+
+    def test_unquoted_value_with_embedded_quoted_hash(self):
+        """非クォート値の途中に埋め込まれたクォート文字列内の#が
+        誤ってコメント扱いされないことを確認"""
+        content = dedent("""
+            ---
+            allowed-tools: Bash(git commit -m "chore: update #123")
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["allowed-tools"] == 'Bash(git commit -m "chore: update #123")'
+
+    def test_unquoted_value_with_multiple_embedded_quotes_and_trailing_comment(self):
+        """非クォート値に複数のクォート区間がある場合でも、
+        区間外の本当のインラインコメントは正しく除去されることを確認"""
+        content = dedent("""
+            ---
+            allowed-tools: Bash(rm "a" "b") # comment
+            ---
+        """).strip()
+        fm, body, warnings = parse_frontmatter(content)
+        assert fm["allowed-tools"] == 'Bash(rm "a" "b")'
+
     def test_value_is_comment_only_becomes_list_key(self):
         """値がシャープ記号のみで始まる場合は空値としてリストキー扱いになることを確認"""
         content = dedent("""

--- a/scripts/validators/base.py
+++ b/scripts/validators/base.py
@@ -68,8 +68,10 @@ def _strip_inline_comment(value: str) -> str:
         if close_idx == -1:
             # 閉じクォートが見つからない場合は値全体をそのまま返す
             return value
-        # クォート内のシャープ記号はコメントとして扱わない
-        if "#" not in value[close_idx + 1 :]:
+        # 閉じクォート後に本当のインラインコメント（半角スペース+シャープ記号）が
+        # 続く場合のみコメントとして切り詰める（非クォート値の規約と統一する。
+        # 例: "text"#anchor のようにスペースなしで#が続く場合はコメット扱いしない）
+        if " #" not in value[close_idx + 1 :]:
             return value
         return value[: close_idx + 1]
 
@@ -77,10 +79,21 @@ def _strip_inline_comment(value: str) -> str:
         # 値全体がコメントだったケース
         return ""
 
-    comment_idx = value.find(" #")
-    if comment_idx == -1:
-        return value
-    return value[:comment_idx].rstrip()
+    # 非クォート値の途中に埋め込まれたクォート文字列（例: Bash(git commit -m "chore: update #123")）
+    # の中の#をコメントとして誤除去しないよう、クォート区間をスキップしながら走査する
+    in_quote: str | None = None
+    i = 0
+    while i < len(value) - 1:
+        ch = value[i]
+        if in_quote:
+            if ch == in_quote:
+                in_quote = None
+        elif ch in ('"', "'"):
+            in_quote = ch
+        elif ch == " " and value[i + 1] == "#":
+            return value[:i].rstrip()
+        i += 1
+    return value
 
 
 def _convert_yaml_value(value: str) -> Any:

--- a/scripts/validators/base.py
+++ b/scripts/validators/base.py
@@ -56,6 +56,33 @@ def _strip_quotes(value: str) -> str:
     return value
 
 
+def _strip_inline_comment(value: str) -> str:
+    """値の末尾に付いたインラインコメント（半角スペース+シャープ記号）を除去する"""
+    value = value.strip()
+    if not value:
+        return value
+
+    if value[0] in ('"', "'"):
+        quote = value[0]
+        close_idx = value.find(quote, 1)
+        if close_idx == -1:
+            # 閉じクォートが見つからない場合は値全体をそのまま返す
+            return value
+        # クォート内のシャープ記号はコメントとして扱わない
+        if "#" not in value[close_idx + 1 :]:
+            return value
+        return value[: close_idx + 1]
+
+    if value.startswith("#"):
+        # 値全体がコメントだったケース
+        return ""
+
+    comment_idx = value.find(" #")
+    if comment_idx == -1:
+        return value
+    return value[:comment_idx].rstrip()
+
+
 def _convert_yaml_value(value: str) -> Any:
     """YAML値を適切なPython型に変換する"""
     unquoted = _strip_quotes(value)
@@ -99,7 +126,7 @@ class _FrontmatterParser:
         if not self._list_key:
             self.warnings.append("リスト/配列はキーの後に続く必要があります")
             return
-        item = "" if stripped == "-" else _strip_quotes(stripped[2:].strip())
+        item = "" if stripped == "-" else _strip_quotes(_strip_inline_comment(stripped[2:].strip()))
         self._list_items.append(item)
 
     def _handle_key_value(self, line: str):
@@ -107,7 +134,7 @@ class _FrontmatterParser:
         self._save_pending_list()
         key, value = line.split(":", 1)
         key = key.strip()
-        value = value.strip()
+        value = _strip_inline_comment(value.strip())
 
         if not value:
             self._list_key = key


### PR DESCRIPTION
## 概要

アーキテクチャレビューで見つかった問題の1つを修正します。

`scripts/validators/base.py` の簡易YAMLフロントマターパーサー（`_FrontmatterParser`）は、行頭が`#`で始まる行（コメント行全体）は`parse_line`内でスキップしていましたが、値の末尾に付いたインラインコメント（例: `model: sonnet # 説明のコメント` のような、コロンの後の値本体に続けて空白+シャープ記号で始まるコメント）を除去する処理がありませんでした。

このため、例えば `model: sonnet # 説明` のようなfrontmatterを書くと、`_handle_key_value`内で`value`が`"sonnet # 説明"`という文字列そのものになってしまい、`agent.py`等のmodelバリデーションが`"sonnet # 説明"`を不正な値として誤警告していました。

## 変更内容

- `scripts/validators/base.py` に、値からインラインコメントを除去するヘルパー関数 `_strip_inline_comment(value: str) -> str` を追加
  - 値がクォート（`"`または`'`）で囲まれている場合、クォート内の`#`はコメントとして扱わず、閉じクォートより後ろに`#`があるときだけそこで切り詰める
  - クォートで囲まれていない場合、値全体が`#`で始まれば空文字列を返し（既存の「値が空ならリストキーとして扱う」挙動に合流）、それ以外は` #`（半角スペース+シャープ）が最初に現れる位置より前を返す
  - 閉じクォートが見つからない場合は値全体をそのまま返す（フォールバック）
- `_handle_key_value`メソッド内、`value = value.strip()`の直後（`_convert_yaml_value`呼び出しより前）に`_strip_inline_comment`を適用
- `_handle_list_item`メソッド内のリスト項目の値抽出箇所にも同様に`_strip_inline_comment`を適用し、リスト項目の値からもインラインコメントを除去できるように修正
- `scripts/tests/test_base.py` にテストケースを追加
  - キー値のインラインコメント除去（`model: sonnet # 説明のコメント`）
  - クォート内の`#`がコメントとして誤除去されないこと（`description: "Use # to comment in bash"`）
  - クォートされた値の後の本当のインラインコメントが除去されること
  - 値が`#`のみで始まる場合に空値としてリストキー扱いになること
  - リスト項目のインラインコメント除去（`- item1 # コメント`）
  - 閉じクォートが見つからない場合に値全体がそのまま保持されること（新規分岐のカバレッジ確保のため追加）

## 確認事項

- `uvx ruff check scripts/` 相当のチェック（環境の制約によりインストール済みの`ruff` 0.14.10を直接使用）: 問題なし
- `uvx ruff format scripts/` 相当のチェック（同上、`--diff`で確認後、フォーマット差分を手動適用して再確認）: フォーマット済み
- `cd scripts && uvx --with pytest-cov pytest tests/ -v --cov=validators --cov-report=term --cov-fail-under=100` 相当のテスト（環境の制約により`pytest`/`pytest-cov`を別途用意して実行）: 527件全テスト成功、カバレッジ100%（`base.py`含む全ファイル100%）を維持
- 対象ファイル（`scripts/validators/base.py`、`scripts/tests/test_base.py`）以外への変更なし

### 補足（作業環境について）

サンドボックス環境の制約により、`uvx`コマンドがネットワーク・キャッシュディレクトリへの書き込みで失敗したため、代わりに環境にインストール済みの`ruff`、および別途取得した`pytest`/`pytest-cov`一式を使って同等のチェックを実行しました。チェック内容・基準（lint/format/pytest --cov-fail-under=100）は指示どおりです。
