### PR TITLE
feat: .mcp.json/.lsp.json の機密情報検出を実装（README記載機能の実装漏れ修正）

### DIFF
--- a/scripts/tests/test_lsp_json.py
+++ b/scripts/tests/test_lsp_json.py
@@ -213,3 +213,75 @@ class TestValidateLspJson:
         result = validate_lsp_json(Path(".lsp.json"), content)
         assert result.has_errors()
         assert any("env" in e and "オブジェクト" in e for e in result.errors)
+
+    def test_hardcoded_secret_detected(self):
+        """ハードコードされた機密情報を含む場合はエラー"""
+        content = json.dumps(
+            {
+                "go": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                    "env": {"GITHUB_TOKEN": "ghp_abcdefghijklmnopqrstuvwxyz1234"},
+                }
+            }
+        )
+        result = validate_lsp_json(Path(".lsp.json"), content)
+        assert result.has_errors()
+        assert any("機密情報" in e for e in result.errors)
+
+    def test_env_placeholder_not_flagged_as_secret(self):
+        """${VAR}形式のプレースホルダーは機密情報として検出されない"""
+        content = json.dumps(
+            {
+                "go": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                    "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"},
+                }
+            }
+        )
+        result = validate_lsp_json(Path(".lsp.json"), content)
+        assert not result.has_errors()
+
+    def test_diagnostics_true(self):
+        """diagnostics: true は有効"""
+        content = json.dumps(
+            {
+                "go": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                    "diagnostics": True,
+                }
+            }
+        )
+        result = validate_lsp_json(Path(".lsp.json"), content)
+        assert not result.has_errors()
+
+    def test_diagnostics_false(self):
+        """diagnostics: false は有効"""
+        content = json.dumps(
+            {
+                "go": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                    "diagnostics": False,
+                }
+            }
+        )
+        result = validate_lsp_json(Path(".lsp.json"), content)
+        assert not result.has_errors()
+
+    def test_diagnostics_invalid_type(self):
+        """diagnosticsがブール値でない（エラー）"""
+        content = json.dumps(
+            {
+                "go": {
+                    "command": "gopls",
+                    "extensionToLanguage": {".go": "go"},
+                    "diagnostics": "true",
+                }
+            }
+        )
+        result = validate_lsp_json(Path(".lsp.json"), content)
+        assert result.has_errors()
+        assert any("diagnostics" in e and "ブール" in e for e in result.errors)

--- a/scripts/tests/test_mcp_json.py
+++ b/scripts/tests/test_mcp_json.py
@@ -201,3 +201,43 @@ class TestValidateMcpJson:
         )
         result = validate_mcp_json(Path(".mcp.json"), content)
         assert not result.has_errors()
+
+    def test_hardcoded_secret_detected(self):
+        """ハードコードされた機密情報を含む場合はエラー"""
+        content = json.dumps(
+            {
+                "mcpServers": {
+                    "test-server": {
+                        "type": "stdio",
+                        "command": "node",
+                        "env": {"OPENAI_API_KEY": "sk-abcdefghijklmnopqrstuvwxyz123456"},
+                    }
+                }
+            }
+        )
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("機密情報" in e for e in result.errors)
+
+    def test_env_placeholder_not_flagged_as_secret(self):
+        """${VAR}形式のプレースホルダーは機密情報として検出されない"""
+        content = json.dumps(
+            {
+                "mcpServers": {
+                    "test-server": {
+                        "type": "stdio",
+                        "command": "node",
+                        "env": {"OPENAI_API_KEY": "${OPENAI_API_KEY}"},
+                    }
+                }
+            }
+        )
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_server_config_not_dict(self):
+        """サーバー設定がオブジェクトでない場合はクラッシュせずエラーになる"""
+        content = json.dumps({"mcpServers": {"test-server": "invalid"}})
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("設定はオブジェクトが必要" in e for e in result.errors)

--- a/scripts/tests/test_mcp_json.py
+++ b/scripts/tests/test_mcp_json.py
@@ -255,3 +255,11 @@ class TestValidateMcpJson:
         result = validate_mcp_json(Path(".mcp.json"), content)
         assert result.has_errors()
         assert any("設定はオブジェクトが必要" in e for e in result.errors)
+
+    def test_reserved_name_and_non_dict_config_both_reported(self):
+        """予約済みサーバー名かつ設定が非オブジェクトの場合、
+        両方のエラーが報告されることを確認（チェック順序の修正）"""
+        content = json.dumps({"mcpServers": {"workspace": "invalid"}})
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert any("予約済みサーバー名" in e for e in result.errors)
+        assert any("設定はオブジェクトが必要" in e for e in result.errors)

--- a/scripts/tests/test_mcp_json.py
+++ b/scripts/tests/test_mcp_json.py
@@ -67,6 +67,20 @@ class TestValidateMcpJson:
         assert not result.has_errors()
         assert any("空" in w for w in result.warnings)
 
+    def test_mcp_servers_not_dict(self):
+        """mcpServers自体がオブジェクトでない場合（配列）、クラッシュせずエラーになることをテスト"""
+        content = json.dumps({"mcpServers": ["invalid"]})
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("mcpServersはオブジェクトが必要です" in e for e in result.errors)
+
+    def test_mcp_servers_not_dict_string(self):
+        """mcpServers自体がオブジェクトでない場合（文字列）、クラッシュせずエラーになることをテスト"""
+        content = json.dumps({"mcpServers": "invalid"})
+        result = validate_mcp_json(Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("mcpServersはオブジェクトが必要です" in e for e in result.errors)
+
     def test_stdio_missing_command(self):
         content = json.dumps({"mcpServers": {"test-server": {"type": "stdio"}}})
         result = validate_mcp_json(Path(".mcp.json"), content)

--- a/scripts/tests/test_secret_detection.py
+++ b/scripts/tests/test_secret_detection.py
@@ -4,9 +4,8 @@ secret_detection.py のテスト
 
 from pathlib import Path
 
-from scripts.validators.secret_detection import detect_hardcoded_secrets
-
 from scripts.validators.base import ValidationResult
+from scripts.validators.secret_detection import detect_hardcoded_secrets
 
 
 class TestDetectHardcodedSecrets:

--- a/scripts/tests/test_secret_detection.py
+++ b/scripts/tests/test_secret_detection.py
@@ -1,0 +1,127 @@
+"""
+secret_detection.py のテスト
+"""
+
+from pathlib import Path
+
+from scripts.validators.base import ValidationResult
+from scripts.validators.secret_detection import detect_hardcoded_secrets
+
+
+class TestDetectHardcodedSecrets:
+    """detect_hardcoded_secretsのテスト"""
+
+    def test_openai_api_key_detected(self):
+        """OpenAI APIキーのハードコードを検出する"""
+        content = '{"env": {"OPENAI_API_KEY": "sk-abcdefghijklmnopqrstuvwxyz123456"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("OpenAI APIキー" in e for e in result.errors)
+
+    def test_openai_api_key_proj_detected(self):
+        """OpenAI APIキー（sk-proj-）のハードコードを検出する"""
+        content = '{"env": {"OPENAI_API_KEY": "sk-proj-abcdefghijklmnopqrstuvwxyz123456"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("OpenAI APIキー" in e for e in result.errors)
+
+    def test_openai_api_key_placeholder_not_detected(self):
+        """${VAR}形式のプレースホルダーは検出しない"""
+        content = '{"env": {"OPENAI_API_KEY": "${OPENAI_API_KEY}"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_github_token_detected(self):
+        """GitHub Tokenのハードコードを検出する"""
+        content = '{"env": {"GITHUB_TOKEN": "ghp_abcdefghijklmnopqrstuvwxyz1234"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("GitHub Token" in e for e in result.errors)
+
+    def test_github_token_variants_detected(self):
+        """GitHub Tokenの各プレフィックス（gho_/ghu_/ghs_）を検出する"""
+        for prefix in ("gho_", "ghu_", "ghs_"):
+            content = f'{{"token": "{prefix}abcdefghijklmnopqrstuvwxyz1234"}}'
+            result = ValidationResult()
+            detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+            assert result.has_errors(), f"{prefix} should be detected"
+            assert any("GitHub Token" in e for e in result.errors)
+
+    def test_github_token_placeholder_not_detected(self):
+        """${VAR}形式のプレースホルダーは検出しない"""
+        content = '{"env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_slack_token_detected(self):
+        """Slack Tokenのハードコードを検出する"""
+        content = '{"env": {"SLACK_TOKEN": "xoxb-1234567890-abcdefghij"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("Slack Token" in e for e in result.errors)
+
+    def test_slack_token_variants_detected(self):
+        """Slack Tokenの各プレフィックス（xoxa-/xoxp-）を検出する"""
+        for prefix in ("xoxa-", "xoxp-"):
+            content = f'{{"token": "{prefix}1234567890-abcdefghij"}}'
+            result = ValidationResult()
+            detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+            assert result.has_errors(), f"{prefix} should be detected"
+            assert any("Slack Token" in e for e in result.errors)
+
+    def test_slack_token_placeholder_not_detected(self):
+        """${VAR}形式のプレースホルダーは検出しない"""
+        content = '{"env": {"SLACK_TOKEN": "${SLACK_TOKEN}"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_aws_access_key_detected(self):
+        """AWS Access Key IDのハードコードを検出する"""
+        content = '{"env": {"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("AWS Access Key ID" in e for e in result.errors)
+
+    def test_aws_access_key_placeholder_not_detected(self):
+        """${VAR}形式のプレースホルダーは検出しない"""
+        content = '{"env": {"AWS_ACCESS_KEY_ID": "${AWS_ACCESS_KEY_ID}"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_google_api_key_detected(self):
+        """Google APIキーのハードコードを検出する"""
+        content = '{"env": {"GOOGLE_API_KEY": "AIzaFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAK"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("Google APIキー" in e for e in result.errors)
+
+    def test_google_api_key_placeholder_not_detected(self):
+        """${VAR}形式のプレースホルダーは検出しない"""
+        content = '{"env": {"GOOGLE_API_KEY": "${GOOGLE_API_KEY}"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_no_secrets_no_errors(self):
+        """機密情報がない場合はエラーなし"""
+        content = '{"env": {"FOO": "${FOO:-bar}", "PATH": "/usr/local/bin"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert not result.has_errors()
+
+    def test_error_message_mentions_var_placeholder(self):
+        """エラーメッセージに${VAR}形式の案内が含まれる"""
+        content = '{"env": {"OPENAI_API_KEY": "sk-abcdefghijklmnopqrstuvwxyz123456"}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert any("${VAR}" in e for e in result.errors)

--- a/scripts/tests/test_secret_detection.py
+++ b/scripts/tests/test_secret_detection.py
@@ -112,6 +112,15 @@ class TestDetectHardcodedSecrets:
         detect_hardcoded_secrets(result, Path(".mcp.json"), content)
         assert not result.has_errors()
 
+    def test_google_api_key_ending_with_hyphen_detected(self):
+        """鍵の末尾がハイフンの場合でも\\b境界判定に依存せず検出されることを確認"""
+        key = "AIza" + "A" * 34 + "-"
+        content = f'{{"env": {{"GOOGLE_API_KEY": "{key}"}}}}'
+        result = ValidationResult()
+        detect_hardcoded_secrets(result, Path(".mcp.json"), content)
+        assert result.has_errors()
+        assert any("Google APIキー" in e for e in result.errors)
+
     def test_no_secrets_no_errors(self):
         """機密情報がない場合はエラーなし"""
         content = '{"env": {"FOO": "${FOO:-bar}", "PATH": "/usr/local/bin"}}'

--- a/scripts/tests/test_secret_detection.py
+++ b/scripts/tests/test_secret_detection.py
@@ -4,8 +4,9 @@ secret_detection.py のテスト
 
 from pathlib import Path
 
-from scripts.validators.base import ValidationResult
 from scripts.validators.secret_detection import detect_hardcoded_secrets
+
+from scripts.validators.base import ValidationResult
 
 
 class TestDetectHardcodedSecrets:

--- a/scripts/validators/lsp_json.py
+++ b/scripts/validators/lsp_json.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 from .base import ValidationResult, parse_json_safe
+from .secret_detection import detect_hardcoded_secrets
 
 # 有効なtransport値
 VALID_TRANSPORTS = {"stdio", "socket"}
@@ -17,6 +18,8 @@ def validate_lsp_json(file_path: Path, content: str) -> ValidationResult:
     data = parse_json_safe(content, file_path, result)
     if data is None:
         return result
+
+    detect_hardcoded_secrets(result, file_path, content)
 
     if not data:
         result.add_warning(f"{file_path.name}: LSPサーバー設定が空です")
@@ -75,6 +78,10 @@ def validate_lsp_json(file_path: Path, content: str) -> ValidationResult:
         restart_on_crash = config.get("restartOnCrash")
         if restart_on_crash is not None and not isinstance(restart_on_crash, bool):
             result.add_error(f"{file_path.name}: {server_name}: restartOnCrashはブール値が必要")
+
+        diagnostics = config.get("diagnostics")
+        if diagnostics is not None and not isinstance(diagnostics, bool):
+            result.add_error(f"{file_path.name}: {server_name}: diagnosticsはブール値が必要")
 
         # envのバリデーション
         env = config.get("env")

--- a/scripts/validators/mcp_json.py
+++ b/scripts/validators/mcp_json.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 from .base import ValidationResult, parse_json_safe
+from .secret_detection import detect_hardcoded_secrets
 
 RESERVED_SERVER_NAMES = {"workspace"}
 
@@ -17,12 +18,18 @@ def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
     if data is None:
         return result
 
+    detect_hardcoded_secrets(result, file_path, content)
+
     servers = data.get("mcpServers", {})
     if not servers:
         result.add_warning(f"{file_path.name}: mcpServersが空です")
         return result
 
     for server_name, config in servers.items():
+        if not isinstance(config, dict):
+            result.add_error(f"{file_path.name}: {server_name}: 設定はオブジェクトが必要")
+            continue
+
         if server_name in RESERVED_SERVER_NAMES:
             result.add_error(
                 f"{file_path.name}: '{server_name}' は予約済みサーバー名です（v2.1.128以降）。"

--- a/scripts/validators/mcp_json.py
+++ b/scripts/validators/mcp_json.py
@@ -21,6 +21,9 @@ def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
     detect_hardcoded_secrets(result, file_path, content)
 
     servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        result.add_error(f"{file_path.name}: mcpServersはオブジェクトが必要です")
+        return result
     if not servers:
         result.add_warning(f"{file_path.name}: mcpServersが空です")
         return result

--- a/scripts/validators/mcp_json.py
+++ b/scripts/validators/mcp_json.py
@@ -29,15 +29,16 @@ def validate_mcp_json(file_path: Path, content: str) -> ValidationResult:
         return result
 
     for server_name, config in servers.items():
-        if not isinstance(config, dict):
-            result.add_error(f"{file_path.name}: {server_name}: 設定はオブジェクトが必要")
-            continue
-
         if server_name in RESERVED_SERVER_NAMES:
             result.add_error(
                 f"{file_path.name}: '{server_name}' は予約済みサーバー名です（v2.1.128以降）。"
                 "使用すると警告とともにスキップされます"
             )
+
+        if not isinstance(config, dict):
+            result.add_error(f"{file_path.name}: {server_name}: 設定はオブジェクトが必要")
+            continue
+
         server_type = config.get("type", "stdio")
 
         if server_type == "stdio":

--- a/scripts/validators/secret_detection.py
+++ b/scripts/validators/secret_detection.py
@@ -18,7 +18,10 @@ SECRET_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("GitHub Token", re.compile(r"\bgh[pous]_[A-Za-z0-9]{20,}\b")),
     ("Slack Token", re.compile(r"\bxox[bap]-[A-Za-z0-9-]{10,}\b")),
     ("AWS Access Key ID", re.compile(r"\bAKIA[A-Z0-9]{16}\b")),
-    ("Google APIキー", re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")),
+    # 末尾の文字クラスにハイフンを含むため\bでは境界判定できないケースが
+    # ある（鍵の末尾がハイフンで直後がクォート等の非単語文字だと\bが不成立
+    # になる）。(?![A-Za-z0-9_])という先読みに置き換えて対処する
+    ("Google APIキー", re.compile(r"\bAIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_])")),
 ]
 
 

--- a/scripts/validators/secret_detection.py
+++ b/scripts/validators/secret_detection.py
@@ -1,0 +1,39 @@
+"""
+機密情報（ハードコードされたAPIキー等）の検出
+
+.mcp.json / .lsp.json 内にAPIキーやトークンが直接書かれていないかを
+正規表現で検出する共通ヘルパー。
+"""
+
+import re
+from pathlib import Path
+
+from .base import ValidationResult
+
+# 各パターンは (パターン名, 正規表現) のタプル
+# ${VAR} のような環境変数プレースホルダーには決してマッチしないよう、
+# `$`や`{`を含まない文字クラスのみを使用する
+SECRET_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("OpenAI APIキー", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9]{20,}\b")),
+    ("GitHub Token", re.compile(r"\bgh[pous]_[A-Za-z0-9]{20,}\b")),
+    ("Slack Token", re.compile(r"\bxox[bap]-[A-Za-z0-9-]{10,}\b")),
+    ("AWS Access Key ID", re.compile(r"\bAKIA[A-Z0-9]{16}\b")),
+    ("Google APIキー", re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")),
+]
+
+
+def detect_hardcoded_secrets(result: ValidationResult, file_path: Path, content: str) -> None:
+    """
+    コンテンツ中にハードコードされた機密情報のパターンがないか検出する
+
+    Args:
+        result: 検証結果オブジェクト（検出時にエラーを追加）
+        file_path: エラーメッセージ用のファイルパス
+        content: 検査対象のファイル内容全体
+    """
+    for pattern_name, pattern in SECRET_PATTERNS:
+        if pattern.search(content):
+            result.add_error(
+                f"{file_path.name}: {pattern_name}のようなハードコードされた機密情報を"
+                "検出しました。${VAR}形式で環境変数から参照してください"
+            )


### PR DESCRIPTION
## 概要

`scripts/README.md` の「機密情報検出」節は、`.mcp.json` と `.lsp.json` で以下の機密情報パターンを検出してエラー報告する、と明記していました。

- OpenAI APIキー（`sk-`, `sk-proj-`）
- GitHub Token（`ghp_`, `gho_`, `ghu_`, `ghs_`）
- Slack Token（`xoxb-`, `xoxa-`, `xoxp-`）
- AWS Access Key ID（`AKIA...`）
- Google APIキー（`AIza...`）

しかし実際には `scripts/validators/mcp_json.py` にも `scripts/validators/lsp_json.py` にもこの検出ロジックが実装されておらず、ドキュメントが実装されていない機能を約束している状態でした。本PRはこのアーキテクチャレビュー指摘（ドキュメントと実装の不一致）を解消します。

## 変更内容

### 新規: `scripts/validators/secret_detection.py`

- 上記5パターンに対応する正規表現を定義した `SECRET_PATTERNS`
- コンテンツ文字列中にパターンがマッチした場合に `ValidationResult` へエラーを追加する `detect_hardcoded_secrets(result, file_path, content)`
- `${VAR}` のような環境変数プレースホルダー構文（`$`, `{`, `}` を含む文字列）には正規表現の文字クラスの都合上マッチしないことをテストで確認済み

### `scripts/validators/mcp_json.py`

- JSONパース成功直後（`servers` の空チェックより前）に `detect_hardcoded_secrets` を呼び出すよう追加
- `for server_name, config in servers.items():` ループ内に、`config` が `dict` でない場合の型ガード（`result.add_error` して `continue`）を追加。`lsp_json.py` には既に同様のガードがありましたが `mcp_json.py` には欠けていたため、今回あわせて追加しました

### `scripts/validators/lsp_json.py`

- JSONパース成功直後（空チェックより前）に `detect_hardcoded_secrets` を呼び出すよう追加
- `.claude/rules/lsp-servers.md` に記載がある `diagnostics` フィールド（boolean、省略時true）について、既存の `restartOnCrash` と同様のパターンでバリデーションを追加

### テスト

- `scripts/tests/test_secret_detection.py`（新規）: 5パターンそれぞれの「検出される正例」「`${VAR}` 形式のプレースホルダーでは検出されない負例」をテスト
- `scripts/tests/test_mcp_json.py`: 機密情報検出のテスト、`config` が dict でない場合にクラッシュせずエラーになるテストを追加
- `scripts/tests/test_lsp_json.py`: 機密情報検出のテスト、`diagnostics` フィールドの正常系（true/false）・異常系（bool以外）のテストを追加

## 確認事項

- `python3 -m ruff check scripts/` / `ruff format --check scripts/`: 問題なし
- `pytest scripts/tests/ -v --cov=validators --cov-report=term --cov-fail-under=100`: 544件全テスト成功、カバレッジ100%を維持
- `gitleaks detect --config .gitleaks.toml`: リークなし（テストファイルはallowlist対象）
- 指示された6ファイル（`secret_detection.py` 新規、`mcp_json.py`、`lsp_json.py`、対応するテスト3ファイル）以外は変更していません
- `scripts/validators/__init__.py` は指示どおり変更していません（`secret_detection.py` は内部ヘルパーとして直接importされるのみ）
