### PR TITLE
feat: marketplace.json のsourceタイプ別必須フィールド(repo/url/package/path)検証を追加

### DIFF
--- a/scripts/tests/test_marketplace_json.py
+++ b/scripts/tests/test_marketplace_json.py
@@ -670,6 +670,236 @@ class TestValidateMarketplaceJson:
         assert any("skipLfs" in e and "boolean" in e for e in result.errors)
 
 
+class TestSourceTypeRequiredFields:
+    """source_type別の必須サブフィールド検証のテスト"""
+
+    def test_source_github_missing_repo(self):
+        """source: githubでrepoが欠けている（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "github"}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.repo" in e and "必須" in e for e in result.errors)
+
+    def test_source_github_repo_not_string(self):
+        """source: githubでrepoが文字列でない（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "github", "repo": 123}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.repo" in e and "文字列が必要" in e for e in result.errors)
+
+    def test_source_url_missing_url(self):
+        """source: urlでurlが欠けている（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "url"}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.url" in e and "必須" in e for e in result.errors)
+
+    def test_source_url_url_not_string(self):
+        """source: urlでurlが文字列でない（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "url", "url": 123}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.url" in e and "文字列が必要" in e for e in result.errors)
+
+    def test_plugin_source_npm(self):
+        """source: npmが有効であることをテスト"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {"source": "npm", "package": "my-claude-plugin"},
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert not result.has_errors()
+
+    def test_plugin_source_npm_with_version_and_registry(self):
+        """source: npmでversion・registryを指定しても有効"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {
+                            "source": "npm",
+                            "package": "@company/my-claude-plugin",
+                            "version": "1.2.3",
+                            "registry": "https://registry.company.internal",
+                        },
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert not result.has_errors()
+
+    def test_source_npm_missing_package(self):
+        """source: npmでpackageが欠けている（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "npm"}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.package" in e and "必須" in e for e in result.errors)
+
+    def test_source_npm_package_not_string(self):
+        """source: npmでpackageが文字列でない（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "npm", "package": 123}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.package" in e and "文字列が必要" in e for e in result.errors)
+
+    def test_source_git_subdir_missing_url(self):
+        """source: git-subdirでurlが欠けている（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {"source": "git-subdir", "path": "packages/my-plugin"},
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.url" in e and "必須" in e for e in result.errors)
+
+    def test_source_git_subdir_missing_path(self):
+        """source: git-subdirでpathが欠けている（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {
+                            "source": "git-subdir",
+                            "url": "https://github.com/owner/monorepo.git",
+                        },
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.path" in e and "必須" in e for e in result.errors)
+
+    def test_source_git_subdir_missing_both(self):
+        """source: git-subdirでurl・pathの両方が欠けている（両方エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "git-subdir"}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.url" in e and "必須" in e for e in result.errors)
+        assert any("source.path" in e and "必須" in e for e in result.errors)
+
+    def test_source_git_subdir_url_not_string(self):
+        """source: git-subdirでurlが文字列でない（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {
+                            "source": "git-subdir",
+                            "url": 123,
+                            "path": "packages/my-plugin",
+                        },
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.url" in e and "文字列が必要" in e for e in result.errors)
+
+    def test_source_git_subdir_path_not_string(self):
+        """source: git-subdirでpathが文字列でない（エラー）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [
+                    {
+                        "name": "plugin-one",
+                        "source": {
+                            "source": "git-subdir",
+                            "url": "https://github.com/owner/monorepo.git",
+                            "path": 123,
+                        },
+                    }
+                ],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert result.has_errors()
+        assert any("source.path" in e and "文字列が必要" in e for e in result.errors)
+
+    def test_plugin_source_settings_no_extra_fields_required(self):
+        """source: settingsは追加フィールドなしで有効（回帰確認）"""
+        content = json.dumps(
+            {
+                "name": "my-marketplace",
+                "owner": {"name": "Team Name"},
+                "plugins": [{"name": "plugin-one", "source": {"source": "settings"}}],
+            }
+        )
+        result = validate_marketplace_json(Path("marketplace.json"), content)
+        assert not result.has_errors()
+
+
 class TestRenames:
     """marketplace.json の renames フィールドのテスト（v2.1.193以降）"""
 

--- a/scripts/validators/marketplace_json.py
+++ b/scripts/validators/marketplace_json.py
@@ -143,4 +143,62 @@ def validate_marketplace_json(file_path: Path, content: str) -> ValidationResult
                                 f"{file_path.name}: plugins[{i}].source.skipLfsはbooleanが必要です"
                             )
 
+                    # source_type別の必須サブフィールドの検証
+                    if source_type == "github":
+                        repo = source.get("repo")
+                        if not repo:
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.repoは必須です"
+                                "（source: github）"
+                            )
+                        elif not isinstance(repo, str):
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.repoは文字列が必要です"
+                            )
+                    elif source_type == "url":
+                        url = source.get("url")
+                        if not url:
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.urlは必須です"
+                                "（source: url）"
+                            )
+                        elif not isinstance(url, str):
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.urlは文字列が必要です"
+                            )
+                    elif source_type == "npm":
+                        package = source.get("package")
+                        if not package:
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.packageは必須です"
+                                "（source: npm）"
+                            )
+                        elif not isinstance(package, str):
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.packageは文字列が必要です"
+                            )
+                    elif source_type == "git-subdir":
+                        url = source.get("url")
+                        if not url:
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.urlは必須です"
+                                "（source: git-subdir）"
+                            )
+                        elif not isinstance(url, str):
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.urlは文字列が必要です"
+                            )
+
+                        path = source.get("path")
+                        if not path:
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.pathは必須です"
+                                "（source: git-subdir）"
+                            )
+                        elif not isinstance(path, str):
+                            result.add_error(
+                                f"{file_path.name}: plugins[{i}].source.pathは文字列が必要です"
+                            )
+                    # source_type == "settings" の場合、追加の必須フィールドなし
+
     return result

--- a/scripts/validators/marketplace_json.py
+++ b/scripts/validators/marketplace_json.py
@@ -17,6 +17,14 @@ RESERVED_NAMES = {
     "life-sciences",
 }
 
+# source_type別の必須サブフィールド一覧（settingsは追加の必須フィールドなし）
+REQUIRED_FIELDS_BY_SOURCE_TYPE = {
+    "github": ["repo"],
+    "url": ["url"],
+    "npm": ["package"],
+    "git-subdir": ["url", "path"],
+}
+
 
 def validate_marketplace_json(file_path: Path, content: str) -> ValidationResult:
     """marketplace.jsonを検証する"""
@@ -144,60 +152,17 @@ def validate_marketplace_json(file_path: Path, content: str) -> ValidationResult
                             )
 
                     # source_type別の必須サブフィールドの検証
-                    if source_type == "github":
-                        repo = source.get("repo")
-                        if not repo:
+                    for field in REQUIRED_FIELDS_BY_SOURCE_TYPE.get(source_type, []):
+                        field_value = source.get(field)
+                        if not field_value:
                             result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.repoは必須です"
-                                "（source: github）"
+                                f"{file_path.name}: plugins[{i}].source.{field}は必須です"
+                                f"（source: {source_type}）"
                             )
-                        elif not isinstance(repo, str):
+                        elif not isinstance(field_value, str):
                             result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.repoは文字列が必要です"
-                            )
-                    elif source_type == "url":
-                        url = source.get("url")
-                        if not url:
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.urlは必須です"
-                                "（source: url）"
-                            )
-                        elif not isinstance(url, str):
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.urlは文字列が必要です"
-                            )
-                    elif source_type == "npm":
-                        package = source.get("package")
-                        if not package:
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.packageは必須です"
-                                "（source: npm）"
-                            )
-                        elif not isinstance(package, str):
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.packageは文字列が必要です"
-                            )
-                    elif source_type == "git-subdir":
-                        url = source.get("url")
-                        if not url:
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.urlは必須です"
-                                "（source: git-subdir）"
-                            )
-                        elif not isinstance(url, str):
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.urlは文字列が必要です"
-                            )
-
-                        path = source.get("path")
-                        if not path:
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.pathは必須です"
-                                "（source: git-subdir）"
-                            )
-                        elif not isinstance(path, str):
-                            result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.pathは文字列が必要です"
+                                f"{file_path.name}: plugins[{i}].source.{field}は"
+                                "文字列が必要です"
                             )
                     # source_type == "settings" の場合、追加の必須フィールドなし
 

--- a/scripts/validators/marketplace_json.py
+++ b/scripts/validators/marketplace_json.py
@@ -161,8 +161,7 @@ def validate_marketplace_json(file_path: Path, content: str) -> ValidationResult
                             )
                         elif not isinstance(field_value, str):
                             result.add_error(
-                                f"{file_path.name}: plugins[{i}].source.{field}は"
-                                "文字列が必要です"
+                                f"{file_path.name}: plugins[{i}].source.{field}は文字列が必要です"
                             )
                     # source_type == "settings" の場合、追加の必須フィールドなし
 


### PR DESCRIPTION
## 概要

アーキテクチャレビューで発見された `scripts/validators/marketplace_json.py` の検証漏れを修正しました。`.claude-plugin/marketplace.json` の `plugins[].source` がオブジェクト形式の場合、`.claude/rules/marketplace.md` で定義されている source タイプ別の必須サブフィールドが一切検証されておらず、例えば `{"source": "github"}` のように `repo` フィールドが欠けていてもエラーになりませんでした。

## 変更内容

`validate_marketplace_json` 関数内、`source_type` が有効な5値（`github`/`url`/`npm`/`git-subdir`/`settings`）のいずれかであることを確認した後（既存の `skipLfs` 検証と同じ階層）に、source タイプ別の必須サブフィールドチェックを追加しました。

| source | 必須サブフィールド | 検証内容 |
|--------|-------------------|---------|
| `github` | `repo` | 必須・文字列であることを検証 |
| `url` | `url` | 必須・文字列であることを検証 |
| `npm` | `package` | 必須・文字列であることを検証（`version`・`registry`は引き続き任意） |
| `git-subdir` | `url` と `path` | 両方独立して必須・文字列であることを検証（両方欠けていれば両方エラーになる） |
| `settings` | なし | 追加チェックなし |

既存の `skipLfs` 検証ロジックとは独立させ、互いに干渉しないようにしています。既存の `source.source` 値自体の妥当性チェック（有効な5値かどうか）は変更していません。

## テスト

`scripts/tests/test_marketplace_json.py` に `TestSourceTypeRequiredFields` クラスを追加し、以下を網羅しました。

- `github`: `repo` 欠落時のエラー、`repo` が文字列でない場合のエラー
- `url`: `url` 欠落時のエラー、`url` が文字列でない場合のエラー
- `npm`: 正常系（`package` のみ／`version`・`registry` 併用）、`package` 欠落時のエラー、`package` が文字列でない場合のエラー（npmソースタイプの正常系テストがこれまで存在しなかったため新規追加）
- `git-subdir`: `url` のみ欠落、`path` のみ欠落、両方欠落（両方エラーになることを確認）、それぞれが文字列でない場合のエラー
- `settings`: 追加フィールドなしで有効であることの回帰確認
- 既存の github/url/git-subdir の正常系テスト（`repo`・`url`・`path` が正しく指定されているケース）が本変更後も引き続きエラーなしで通ることを確認

## 確認事項

- [x] `ruff check scripts/` でlintエラーなし
- [x] `ruff format scripts/` でフォーマット差分なし
- [x] `pytest scripts/tests/ -v --cov=validators --cov-report=term --cov-fail-under=100` で全535件のテストが通過し、カバレッジ100%を維持（新規追加分岐もすべてテストでカバー済み）
- [x] 変更対象は `scripts/validators/marketplace_json.py` と `scripts/tests/test_marketplace_json.py` の2ファイルのみ

### 実行環境に関する補足

このセッションのサンドボックス環境では `uvx` がネットワーク/プロキシ設定の取得時にクラッシュしたため、ローカルにインストール済みの `ruff`、および `pip install --trusted-host` で取得した `pytest`/`pytest-cov` を使って同等のコマンドを実行し、結果を確認しました（実行内容・オプションは指示どおりです）。

🤖 Generated with automated architecture review follow-up
