### PR TITLE
chore: lint/testワークフローにuvのキャッシュを導入

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: uvをセットアップ
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Ruff check
         run: uvx ruff check scripts/
@@ -40,6 +42,8 @@ jobs:
 
       - name: uvをセットアップ
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: yamllint
         run: uvx yamllint -c .yamllint.yml .github/workflows/

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: uvをセットアップ
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: テストを実行（カバレッジ計測）
         working-directory: scripts


### PR DESCRIPTION
## 概要

アーキテクチャレビューで指摘された、CIワークフローにおけるuvキャッシュ未活用の問題を修正します。`lint.yml` と `test-scripts.yml` の両方で `astral-sh/setup-uv@v7` を使用していますが、`enable-cache` が未指定のため、uvのダウンロード・ビルドキャッシュがGitHub Actionsのキャッシュ機構と連携されていませんでした。

## 変更内容

- `.github/workflows/lint.yml`
  - `python-lint` ジョブの「uvをセットアップ」ステップに `with: enable-cache: true` を追加
  - `yaml-lint` ジョブの「uvをセットアップ」ステップに `with: enable-cache: true` を追加
- `.github/workflows/test-scripts.yml`
  - `test` ジョブの「uvをセットアップ」ステップに `with: enable-cache: true` を追加

既存のステップ名・他のステップ内容は変更していません。`markdown-lint` ジョブ（Node.js/npxを使用、uvを使わない）はスコープ外のため変更していません。

## 確認事項

- Pythonコードの変更を伴わないため、pytestの実行は不要と判断しました。
- YAML構文チェック: `python3` + `yaml.safe_load()` で両ファイルの構文が壊れていないことを確認しました（結果: OK）。
- Lintチェック: `yamllint -c .yamllint.yml .github/workflows/` を実行し、エラーがないことを確認しました（終了コード0）。
- 差分は指示された2ファイルのみで、他ファイルへの変更はありません。

🤖 Generated with automated architecture review follow-up

Co-Authored-By: Claude <noreply@anthropic.com>
