### PR TITLE
fix: plugin-improvement-check.ymlのトリガーをpull_request:closedに戻す

### DIFF
--- a/.github/workflows/plugin-improvement-check.yml
+++ b/.github/workflows/plugin-improvement-check.yml
@@ -1,5 +1,14 @@
 name: プラグイン改善チェック
 
+# 【重要】on: に push を追加しないこと。
+# 下記jobはanthropics/claude-code-action@v1を使用しているが、このアクションは
+# pushイベントをサポートしておらず「Unsupported event type: push」で即失敗する。
+# GitHub Actionsキャッシュのscope問題（pull_requestだとgithub.refが
+# refs/pull/<N>/mergeになり別PRのキャッシュを復元できない）を解決したくなっても、
+# トリガーをpushに変えるのは対症療法として誤り。過去に同じ変更で2度壊れている
+# （#392で発覚・修正 → #587で見落として再導入 → #600で再修正）。
+# キャッシュscope問題への対応が必要な場合は、on:はpull_requestのままにして、
+# 別の手段（cache miss時の警告可視化・別ストレージの検討等）で解決すること。
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/plugin-improvement-check.yml
+++ b/.github/workflows/plugin-improvement-check.yml
@@ -1,7 +1,8 @@
 name: プラグイン改善チェック
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [main]
     paths:
       - '.claude/rules/**'
@@ -28,6 +29,10 @@ jobs:
   check-improvements:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # PRがマージされた場合のみ実行（クローズのみは除外）
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v7
@@ -51,10 +56,10 @@ jobs:
             RULES=$(find .claude/rules -name '*.md' -type f | tr '\n' ',' | sed 's/,$//')
             VALIDATORS=$(find scripts/validators -name '*.py' -type f | tr '\n' ',' | sed 's/,$//')
           else
-            # push（mainへのマージ含む）: 前回チェックポイントからの累積差分を検出
-            # （mainの履歴ベース）。mainブランチへのpushトリガーのため
-            # github.refは常にrefs/heads/mainに固定され、キャッシュのスコープも
-            # 安定して引き継がれる
+            # pull_request: 前回チェックポイントからの累積差分を検出（mainの履歴ベース）
+            # github.refがrefs/pull/<N>/mergeスコープになるため、キャッシュは
+            # 別PRの実行から復元できないことがある（既知の制約。復元できない
+            # 場合は下記のwarningで可視化し、HEAD~1フォールバックで動作継続する）
             if [ -f .plugin-check-sha ]; then
               LAST_SHA=$(tr -d '[:space:]' < .plugin-check-sha)
               if git cat-file -e "${LAST_SHA}" 2>/dev/null; then


### PR DESCRIPTION
## 概要

`plugin-improvement-check.yml`のトリガーを`push: branches: [main]`から`pull_request: types: [closed]`に戻す。

## 背景

PR #587（GitHub Actionsキャッシュへの状態移行）で、キャッシュのスコープ問題（`pull_request`イベントでは`github.ref`が`refs/pull/<N>/merge`になり、別PRのキャッシュを復元できない）を解決する目的でトリガーを`push`に変更した。

しかし`anthropics/claude-code-action@v1`は`push`イベントをサポートしておらず、mainへのpushのたびに以下のエラーで失敗し続けている。

```
##[error]Action failed with error: Unsupported event type: push
```

この制約は過去に一度発生し、PR #392で`pull_request: closed`に修正済みだった。PR #587の作業中にこの既知の制約が見落とされ、リグレッションとして再導入されてしまった。

## 変更内容

- トリガーを`pull_request: types: [closed], branches: [main]`に戻す
- job条件（`github.event.pull_request.merged == true`）を復活
- コメント文言をpull_requestベースの説明に修正

PR #587で導入したActions cacheによる状態永続化（`.plugin-check-sha`のcommit&push廃止）と、キャッシュmiss時の`::warning::`アノテーションはそのまま維持する。キャッシュscope問題自体は既知の制約として残るが、警告により可視化されるため今回は許容する。

## 参考

- 直近の実行はmainへのpushのたびに継続的に失敗している
- 過去の同種修正: #392

## テスト計画

- [ ] マージ後、次のルール/バリデーター変更PRのマージ時に「プラグイン改善チェック」が正常に起動し、`Unsupported event type`エラーが再発しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
