### PR TITLE
fix: CHANGELOG監視CIのmax-turns不足と参照切れプロンプトを修正

### DIFF
--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # yamllint disable-line rule:line-length
-          claude_args: '--max-turns 20 --allowed-tools "Bash(gh issue create:*),Bash(gh issue list:*),Read,Write,Grep,Glob"'
+          claude_args: '--max-turns 40 --allowed-tools "Bash(gh issue create:*),Bash(gh issue list:*),Read,Write,Grep,Glob"'
           prompt: |
             あなたはClaude Codeマーケットプレイスのメンテナーです。
 
@@ -111,7 +111,7 @@ jobs:
 
             1. changelog-diff.txtを読んで、差分の概要を把握
             2. current-changelog.mdを読んで、プラグイン関連の変更候補を特定
-            3. CLAUDE.mdの「Claude Code アップデート時の追跡方針」に従い、各変更を追跡対象/対象外に分類
+            3. .claude/rules/contribution-guide.md の「Claude Code アップデート時の追跡方針」に従い、各変更を追跡対象/対象外に分類
             4. .claude/rules/README.md を読んで、現在のドキュメント構造を把握
             5. 必要に応じて .claude/rules/ 配下の関連ドキュメントを確認
             6. 追跡対象の変更がある場合:

--- a/.github/workflows/changelog-monitor.yml
+++ b/.github/workflows/changelog-monitor.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   monitor-changelog:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- `changelog-monitor.yml` が直近2回(07-18, 07-19)連続で `--max-turns 20` の上限に到達して失敗していたため、`--max-turns` を40に引き上げ
- プロンプトが参照する「CLAUDE.mdの『Claude Code アップデート時の追跡方針』」は、コミット `e1508af` で `.claude/rules/contribution-guide.md` へ移設済みで現在のCLAUDE.mdには存在しなかった。CI内のClaudeが存在しない参照先を探して迷走しターンを浪費していた可能性が高いため、参照先を修正
- 失敗するとスナップショットが更新されず、翌日はさらに大きい差分を同じ制限で処理して再失敗する悪循環に陥っていたため、この修正で解消を狙う

## Test plan
- [x] `pre-commit run --files .github/workflows/changelog-monitor.yml`（yamllint等）がパス
- [ ] 次回のスケジュール実行（毎日9:00 JST）またはmanual dispatch(`force_check`)で、Issue作成まで完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)