### PR TITLE
ci: 権限拒否の内訳を実行ログにも出力し、ruffのバージョンを固定する

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -253,7 +253,9 @@ jobs:
           fi
 
           # 公開リポジトリのため実行ログ全体はアーティファクト化せず、
-          # allowed-tools の調整に必要な「拒否されたツール呼び出し」のみを抽出する
+          # allowed-tools の調整に必要な「拒否されたツール呼び出し」のみを抽出する。
+          # job summaryはREST APIから取得できずUIでしか読めないため、
+          # 同じ内容を実行ログ（stdout）にも出して gh run view --log で追えるようにする。
           {
             echo "### 権限拒否（permission denials）の内訳"
             echo ""
@@ -273,7 +275,7 @@ jobs:
             echo '```'
             echo ""
             echo "</details>"
-          } >> "${GITHUB_STEP_SUMMARY}"
+          } | tee -a "${GITHUB_STEP_SUMMARY}"
 
       - name: 変更があるか確認
         id: check-changes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,14 @@ jobs:
         with:
           enable-cache: true
 
+      # バージョンは .pre-commit-config.yaml の ruff-pre-commit rev と揃える。
+      # 未固定にすると、ruffの更新（例: Markdown内コードブロックの整形対象化）で
+      # 「ローカルのpre-commitは通るがCIだけ落ちる」状態が突然発生する。
       - name: Ruff check
-        run: uvx ruff check scripts/
+        run: uvx ruff@0.14.10 check scripts/
 
       - name: Ruff format check
-        run: uvx ruff format --check scripts/
+        run: uvx ruff@0.14.10 format --check scripts/
 
   yaml-lint:
     name: YAML (yamllint)


### PR DESCRIPTION
## 概要

PR #623 の後続。次の 2 件の CI 基盤の問題を解消します。どちらも #623 の実運用で判明したものです。

## 1. 権限拒否の内訳が読めない

#623 で権限拒否（permission denials）の内訳を job summary に出力するようにしましたが、**job summary は REST API から取得できず UI でしか読めない**ことが分かりました。当初の目的は `allowed-tools` の調整根拠を得ることなので、これでは使えません。

`tee` で実行ログ（stdout）にも同じ内容を出し、`gh run view --log` から追えるようにします。

```bash
# 変更前
} >> "${GITHUB_STEP_SUMMARY}"

# 変更後
} | tee -a "${GITHUB_STEP_SUMMARY}"
```

出力内容は拒否されたツール名とコマンドのみで、#623 の方針どおり実行ログ全体はアーティファクト化しません。公開範囲は job summary と同じ（公開リポジトリの Actions ログ）で、露出は増えません。

## 2. ruff のバージョンが CI とローカルで一致していない

[lint.yml](.github/workflows/lint.yml) は `uvx ruff` をバージョン未固定で実行しており常に最新版が入る一方、`.pre-commit-config.yaml` は `v0.14.10` に固定されています。

この不一致により、**PR #623 で実際に CI が落ちました**。新しい ruff の `ruff format` が Markdown 内の Python コードブロックも整形対象にするようになり、`scripts/README.md` が引っかかったためです。ローカルの `pre-commit run --all-files` は固定版なので通り、CI だけ落ちるという状態でした。

`uvx ruff@0.14.10` として `.pre-commit-config.yaml` の rev と揃えます。

### トレードオフ

固定すると ruff の新しいルールを自動では拾えなくなります。ただし現状は「更新のたびに無関係な PR が突然落ちる」状態で、原因究明のコストの方が大きいと判断しました。ruff を上げる場合は `.pre-commit-config.yaml` の rev と合わせて更新する運用になります（Dependabot が pre-commit をサポートしているため、将来的にはそちらで揃えられます）。

## 検証

- `pre-commit run --all-files` 全項目パス
- `tee -a` が stdout と出力先ファイルの両方に書くことを手元で確認
- `uvx ruff@0.14.10` の記法自体はこの PR の `Python (Ruff)` チェックで検証されます（サンドボックス環境で uvx が動作しないため、ローカルでの事前確認ができていません）

## 関連

- #623 の後続
- この変更が入った後、max-turns で失敗している Issue（#601 / #610 / #622）を再実行して denial の内訳を収集し、`--max-turns` と `allowed-tools` の調整に着手する予定です

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->