### PR TITLE
docs: SessionStartフックのsourceに fork を追加

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -769,6 +769,7 @@ fi
 | `resume` | `--resume`、`--continue`、`/resume` によるセッション再開時 |
 | `clear` | `/clear` 実行時 |
 | `compact` | 自動または手動のコンパクション後 |
+| `fork` | `/fork` などでセッションがフォークとして開始された時 |
 
 他のイベントと同様のmatcherパターン指定が可能です（「matcher の仕様」参照）。例えば `"matcher": "startup|resume"` は新規開始・再開時のみ発火し、省略または `"*"` はすべての開始方法にマッチします。
 
@@ -797,7 +798,7 @@ fi
 
 | フィールド | 型 | 説明 |
 |-----------|---|------|
-| `source` | string | セッションの開始方法。`"startup"`（新規セッション）/ `"resume"`（再開）/ `"clear"`（`/clear` 後）/ `"compact"`（コンパクション後）。matcherはこの値に対して評価される |
+| `source` | string | セッションの開始方法。`"startup"`（新規セッション）/ `"resume"`（再開）/ `"clear"`（`/clear` 後）/ `"compact"`（コンパクション後）/ `"fork"`（フォークとして開始）。matcherはこの値に対して評価される |
 | `agent_type` | string | `--agent`フラグでセッションを開始した場合のエージェント名 |
 
 **`CLAUDE_ENV_FILE`**: SessionStartフックでは`CLAUDE_ENV_FILE`環境変数にファイルパスが設定されます。このファイルに`export KEY=VALUE`形式で環境変数を書き込むと、セッション全体で利用可能になります。


### PR DESCRIPTION
## 概要

Issue #615 の手動対応です。`SessionStart` フックの `source` に `fork` が追加されているのに、ドキュメントへ未反映でした。

## 背景

#615 は自動実装ワークフローが「変更なし」と判定して終了していましたが、これは誤判定でした。上流のCHANGELOGに次の記載があり、実際には対応が必要です。

> Changed SessionStart hooks to report source `"fork"` when a session begins as a fork instead of `"resume"`

## 変更内容

`.claude/rules/hooks.md` の2箇所に追記します。

- `SessionStart` の matcher値の表に `fork` の行を追加
- 入力JSONの `source` フィールドの説明に `"fork"` を追加

## バリデーターの同期について

`contribution-guide.md` は「新しいイベント/オプションを追加 → バリデーターの許可リストに追加」を求めていますが、`scripts/validators/hooks_json.py` は `SessionStart` の matcher について**存在のみ**を検証しており（`events_with_matcher` に含まれるかのチェックのみ）、matcher値の許可リストを持っていません。同ガイドの「該当するバリデーター/テスト自体が存在しないため同期は不要」に該当するため、ドキュメントのみの変更としています。

## 確認事項

- [ ] 記述内容が上流CHANGELOGと整合しているか
- [ ] バージョン注記を書かない方針に沿っているか（経緯は書かず現行挙動のみ記載しています）

## 関連Issue

Closes #615

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->