### PR TITLE
ci: 保護パスへの書き込みを通し、Bash許可を実際に使うコマンドへ絞る

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -245,10 +245,26 @@ jobs:
             - リポジトリに永続的に必要なファイルのみ作成・変更すること
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
-          # 外部由来のCHANGELOGを起点にIssueが自動生成されbotラベルが付与される
-          # 経路があるため、Bashはplugin-updateステップと同様に実行手順で
-          # 必要なコマンドのみに絞る（Edit/Writeのパス制限要否は別途検討）
-          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *),Bash(pre-commit run*)"'
+          # permission-mode: このリポジトリのルールドキュメントは .claude/rules/ にあり、
+          #   .claude はClaude Codeの「保護パス」なので既定では書き込みが必ず承認待ちになる。
+          #   ヘッドレス実行には承認する相手がいないため拒否され、実装が成立しなかった。
+          #   allow ルールは保護パスより後に評価されるため効かず、bypassPermissions が唯一の手段。
+          # disallowed-tools: bypassPermissions でも deny ルールは有効なので、
+          #   次回以降の実行を乗っ取れるファイル（hooks・ワークフロー・設定）だけを塞ぐ。
+          #   Edit ルールは Write を含む全ファイル編集ツールに効く。
+          # allowed-tools: uvx/npx のワイルドカードは任意コード実行に等しく、
+          #   deny ルールはサブプロセスの書き込みには効かないため実際に使うコマンドへ絞る。
+          # max-turns: 実測で成功38〜46 turns、失敗は一律51（上限50に到達）だったため引き上げる。
+          claude_args: >-
+            --max-turns 80
+            --permission-mode bypassPermissions
+            --allowed-tools "Read,Grep,Glob,Edit,Write,
+            Bash(uvx pytest*),Bash(uvx --with pytest-cov pytest*),Bash(uvx ruff*),
+            Bash(python3 scripts/*),Bash(pre-commit run*)"
+            --disallowed-tools "Edit(/.claude/settings.json),
+            Edit(/.claude/settings.local.json),Edit(/.claude/hooks/**),
+            Edit(/.claude/skills/**),Edit(/.mcp.json),Edit(/CLAUDE.md),
+            Edit(/.github/**),Edit(/.pre-commit-config.yaml)"
 
       - name: Claudeで実装を実行（plugin-update）
         if: env.TARGET_LABEL == 'plugin-update'
@@ -300,8 +316,19 @@ jobs:
             - リポジトリに永続的に必要なファイルのみ作成・変更すること
             - issue-body.md, issue-title.txt などの一時ファイルは参照のみで、変更やコミットに含めないこと
 
-          # yamllint disable-line rule:line-length
-          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(uvx *),Bash(python3 scripts/*),Bash(npx *),Bash(pre-commit run*)"'
+          # claude-code-updateステップと同じ設定にする。理由はそちらのコメントを参照。
+          # plugins/ 配下は保護パスではないためbypassPermissionsは必須ではないが、
+          # 2つのステップで権限設定が食い違うと片方だけ更新し忘れる事故が起きる。
+          claude_args: >-
+            --max-turns 80
+            --permission-mode bypassPermissions
+            --allowed-tools "Read,Grep,Glob,Edit,Write,
+            Bash(uvx pytest*),Bash(uvx --with pytest-cov pytest*),Bash(uvx ruff*),
+            Bash(python3 scripts/*),Bash(pre-commit run*)"
+            --disallowed-tools "Edit(/.claude/settings.json),
+            Edit(/.claude/settings.local.json),Edit(/.claude/hooks/**),
+            Edit(/.claude/skills/**),Edit(/.mcp.json),Edit(/CLAUDE.md),
+            Edit(/.github/**),Edit(/.pre-commit-config.yaml)"
 
       - name: 権限拒否の内訳を出力
         if: always()


### PR DESCRIPTION
## 概要

`claude-code-update` 系の自動実装が失敗し続けていた根本原因を修正します。

## 原因

Claude Code は **`.claude` を「保護パス」として扱い、書き込みを既定では必ず承認待ちにします**。ヘッドレス実行には承認する相手がいないため拒否されます。このリポジトリのルールドキュメントは `.claude/rules/` にあるため、実装そのものが成立していませんでした。

[#622](https://github.com/rfdnxbro/claude-code-marketplace/issues/622) の再実行で採取した実データです。

```text
WebSearch: -
Edit:  .claude/rules/plugin-manifest.md
Bash:  cat .claude/settings.json; ... cat ~/.claude/settings.json
Edit:  .claude/rules/plugin-manifest.md
Edit:  .claude/rules/marketplace.md
Bash:  python3 - <<'EOF' ...
Edit:  .claude/rules/marketplace.md
Write: .claude/rules/marketplace.md
```

拒否されているのは全て `.claude/rules/` 配下です。Claude 自身が原因を探るため `cat .claude/settings.json` を試みており、本人にとっても想定外の拒否だったことが分かります。`num_turns` は 51 で、turns の多くが拒否されたツールの再試行に費やされていました。

### 確認した仕様

公式ドキュメント（[permission modes](https://code.claude.com/docs/en/permission-modes)）の記述です。

| モード | 保護パスへの書き込み |
|---|---|
| `default` / `acceptEdits` | プロンプト（ヘッドレスでは拒否） |
| `dontAsk` | 拒否 |
| `auto` | 分類器に委ねる |
| `bypassPermissions` | 許可 |

保護ディレクトリの一覧に `.claude`（`.claude/worktrees` を除く）が含まれます。さらに:

> `permissions.allow` rules in settings files do not pre-approve protected-path writes. The safety check runs before Claude Code evaluates allow rules

つまり `Edit(.claude/rules/**)` のような許可ルールを足しても効きません。`acceptEdits` でも同じです。**`bypassPermissions` が唯一の手段**です。

`claude-code-action` 側も確認しました。tag モードには `--permission-mode acceptEdits` が付きますが、本ワークフローが使うエージェントモードには付きません。ソース中のコメントに「Headless SDK has no prompt handler, so anything that falls through to "ask" is denied」とあります。

## 変更内容

### 1. `--permission-mode bypassPermissions` を追加

### 2. deny ルールで権限昇格経路を塞ぐ

deny ルールは `bypassPermissions` でも有効です（「deny rules and explicit ask rules ... apply in every mode, including `bypassPermissions`」）。次回以降の実行を乗っ取れるファイルだけを `--disallowed-tools` で塞ぎます。

- `.claude/settings.json` / `.claude/settings.local.json`（hooks を仕込める）
- `.claude/hooks/**` / `.claude/skills/**`
- `.mcp.json` / `CLAUDE.md`
- `.github/**` / `.pre-commit-config.yaml`

`Edit(path)` ルールは `Write` を含む全てのファイル編集ツールに効きます（`Write(path)` 形式はパス照合されないため使いません）。

### 3. Bash 許可を実際に使うコマンドへ絞る

`Bash(uvx *)` と `Bash(npx *)` は任意コード実行に等しく、deny ルールはサブプロセスの書き込みには効きません。**結果として、`bypassPermissions` 導入後の方が攻撃面は狭くなります。**

| 変更前 | 変更後 |
|---|---|
| `Bash(uvx *)` | `Bash(uvx pytest*)` / `Bash(uvx --with pytest-cov pytest*)` / `Bash(uvx ruff*)` |
| `Bash(npx *)` | 削除（node 系ツールは pre-commit が管理） |

### 4. `--max-turns` を 50 から 80 へ

実測で成功時 38〜46 turns、失敗時は一律 51（上限 50 に到達）でした。

## 残るリスク

`Bash(python3 scripts/*)` でリポジトリ内のスクリプトを実行できます。`Write` で `scripts/x.py` を作ってから実行すれば deny ルールを迂回できます。これは変更前から同じで、かつその変更は PR に載るため人のレビューを通ります。完全に塞ぐならサンドボックスの導入が必要ですが、別の課題として切り分けます。

## 確認事項

- [ ] `workflow_dispatch` で #622 を再実行し、`.claude/rules/` への Edit が通るか
- [ ] deny 対象（`.github/**` など）への書き込みが拒否されるか
- [ ] 絞った Bash 許可でテストと pre-commit が実行できるか

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rfdnxbro/claude-code-marketplace/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->